### PR TITLE
Support random level entries.

### DIFF
--- a/smc/src/level/level.cpp
+++ b/smc/src/level/level.cpp
@@ -1068,7 +1068,9 @@ cLevel_Entry *cLevel :: Get_Entry( const std::string &name )
 		return NULL;
 	}
 
-	// Search for entry
+	std::vector<cLevel_Entry*> entries;
+
+	// Search for entries matching name
 	for( cSprite_List::iterator itr = m_sprite_manager->objects.begin(); itr != m_sprite_manager->objects.end(); ++itr )
 	{
 		cSprite *obj = (*itr);
@@ -1083,8 +1085,14 @@ cLevel_Entry *cLevel :: Get_Entry( const std::string &name )
 		// found
 		if( level_entry->m_entry_name.compare( name ) == 0 )
 		{
-			return level_entry;
+			entries.push_back(level_entry);
 		}
+	}
+
+	// Return a random entry
+	if (!entries.empty())
+	{
+		return entries[rand() % entries.size()];
 	}
 
 	return NULL;


### PR DESCRIPTION
Since it is possible for multiple level entries in a level to use the same name, this patch takes advantage of that.  In cases where there are more than one entry of the same name, the entry returned is randomly chosen. Level developers can add slight randomness to the course of a level by having an exit that goes to an entry of a level, and then using that same entry name at different places in the destination level.
