### PR TITLE
basic travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
+before_install:
+  # new boost packages (1.54 and 1.55)
+  - sudo add-apt-repository -y ppa:boost-latest/ppa
+  # new cmake (2.8.7 -> 2.18.11)
+  - sudo add-apt-repository -y ppa:kalakris/cmake
+  - sudo apt-get update -qq
+
+install:
+  - >
+   sudo apt-get install -qq cmake gettext bison pkg-config gperf
+   libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev
+   ruby-full rake libglew-dev libpng-dev libpcre3-dev libxml++2.6-dev
+   libfreetype6-dev libdevil-dev libboost-filesystem1.54-dev libboost-chrono1.54-dev
+   libboost-thread1.54-dev
+
+before_script:
+    # pull all sub modules recursively
+  - git submodule update --init --recursive
+    # ubuntu precise does not ship a pkg-config file, fall back to FindXXX.cmake module
+  - sed 's|pkg_check_modules(SDL_TTF REQUIRED SDL_ttf)|find_package(SDL_ttf REQUIRED)|' -i smc/CMakeLists.txt
+
+script:
+  - mkdir smc/build && cd smc/build && cmake .. && make -j2 && sudo make install

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,6 +69,9 @@ SMC on Ubuntu Linux 14.04:
   libsdl-mixer1.2-dev libsdl-image1.2-dev libpcre3-dev libxml++2.6-dev \
   libfreetype6-dev libdevil-dev libboost1.55-all-dev
 
+Linux building is also monitored by travis-ci, a continuous integration
+service: [![Build Status](https://travis-ci.org/Secretchronicles/SMC.svg)][2]
+
 ### Windows dependencies ###
 
 * The FreeImage library.
@@ -138,7 +141,7 @@ have to even touch a Windows system in order to generate the
 executable that will run on Windows, and indeed this is how we produce
 the Windows releases. Regardless whether you compile
 from Git or from a release tarball, you will need a crosscompilation
-toolchain for that. We recommend you to use [MXE][2] for that, which
+toolchain for that. We recommend you to use [MXE][3] for that, which
 includes all dependencies necessary for building SMC. Even more, I
 (Quintus) have set up an MXE fork that contains versions that I know
 to work with SMC.
@@ -270,4 +273,5 @@ $ git submodule update
 Then continue with “Crosscompiling from a released tarball” above.
 
 [1]: http://cmake.org
-[2]: http://mxe.cc
+[2]: https://travis-ci.org/Secretchronicles/SMC
+[3]: http://mxe.cc


### PR DESCRIPTION
What is left to do: go to https://travis-ci.org → authenticate with GitHub → change under user profile (top right corner) to Secretchronicles account (left edge) → click the switch of SMC repo to activate. done.

---

 * builds currently run between 4 and 6 minutes
 * gcc 4.6.3 and clang 3.4 are used (newer versions would be possible, though)
 * project is configured and installed (without special configuration)