### PR TITLE
Fix menu level loading bug

### DIFF
--- a/smc/src/core/filesystem/package_manager.cpp
+++ b/smc/src/core/filesystem/package_manager.cpp
@@ -227,38 +227,58 @@ fs::path cPackage_Manager :: Get_Game_Level_Path(void)
 fs::path cPackage_Manager :: Get_Menu_Level_Path(void)
 {
 	// determine level for the menu
+	fs::path result;
+	std::string level;
 
-	// user preferences
-	std::string level = pPreferences->m_menu_level;
+	// User specified menu level
+	level = pPreferences->m_menu_level;
+	if(!level.empty())
+	{
+		level = level + ".smclvl";
 
-	// current package
-	if(level.empty() && !m_current_package.empty())
-		level = m_packages[m_current_package].menu_level;
+		result = Get_User_Level_Path() / level;
+		if(fs::exists(result))
+			return result;
 
-	// default
-	if(level.empty())
-		level = pPreferences->m_menu_level_default;
-
-	level = level + ".smclvl";
-
-	// find the level
-
-	// user package data dir
-	fs::path result = Get_User_Level_Path() / level;
-
-	// game package data dir
-	if(!fs::exists(result))
 		result = Get_Game_Level_Path() / level;
+		if(fs::exists(result))
+			return result;
 
-	// user core data dir
-	if(!fs::exists(result))
 		result = pResource_Manager->Get_User_Level_Directory() / level;
+		if(fs::exists(result))
+			return result;
 
-	// finally, game core data dir
-	if(!fs::exists(result))
 		result = pResource_Manager->Get_Game_Level_Directory() / level;
+		if(fs::exists(result))
+			return result;
+	}
 
-	return result;
+	// Package menu
+	if(!m_current_package.empty())
+	{
+		level = m_packages[m_current_package].menu_level;
+		if(!level.empty())
+		{
+			level = level + ".smclvl";
+
+			result = Get_User_Level_Path() / level;
+			if(fs::exists(result))
+				return result;
+
+			result = Get_Game_Level_Path() / level;
+			if(fs::exists(result))
+				return result;
+		}
+	}
+
+	// Default menu level
+	level = pPreferences->m_menu_level_default + ".smclvl";
+
+	result = pResource_Manager->Get_User_Level_Directory() / level;
+	if(fs::exists(result))
+		return result;
+
+	return pResource_Manager->Get_Game_Level_Directory() / level;
 }
 
 fs::path cPackage_Manager :: Get_User_Campaign_Path(void)

--- a/smc/src/gui/menu.cpp
+++ b/smc/src/gui/menu.cpp
@@ -114,7 +114,17 @@ void cMenu_Item :: Draw( cSurface_Request *request /* = NULL */ )
 
 cMenuHandler :: cMenuHandler( void )
 {
-	m_level = cLevel::Load_From_File( pPackage_Manager->Get_Menu_Level_Path() );
+	boost::filesystem::path lvl_path = pPackage_Manager->Get_Menu_Level_Path();
+	if(boost::filesystem::exists(lvl_path))
+	{
+		m_level = cLevel::Load_From_File( lvl_path );
+	}
+	else
+	{
+		// at least give it something so it doesn't crash
+		m_level = new cLevel();
+	}
+
 	m_camera = new cCamera( m_level->m_sprite_manager );
 	m_player = new cSprite( m_level->m_sprite_manager );
 	m_player->Set_Massive_Type( MASS_PASSIVE );


### PR DESCRIPTION
This fixes a bug if the user specifies a level for the menu level that does not exist.  Normally, the menu would crash in such a case.  This fix changes the package manager to better find the menu level, and also changes the menu so that if a level does not exist, it will use an empty level.
