### PR TITLE
Fix libdl usage

### DIFF
--- a/tsc/CMakeLists.txt
+++ b/tsc/CMakeLists.txt
@@ -347,7 +347,7 @@ else()
     ${LibXmlPP_LIBRARIES}
     ${PNG_LIBRARIES}
     ${FREETYPE_LIBRARIES}
-    dl
+    ${CMAKE_DL_LIBS}
     )
 endif()
 


### PR DESCRIPTION
For instance, it's not needed/does not exist on FreeBSD. ${CMAKE_DL_LIBS} handles this automatically.
