### PR TITLE
Pip Stuck Fixes and Pip Floating Fix - Please Test for Computers with Different CPU Speed...

### DIFF
--- a/tsc/src/enemies/pip.cpp
+++ b/tsc/src/enemies/pip.cpp
@@ -305,7 +305,7 @@ void cPip::Handle_Collision_Player(cObjectCollision* p_collision)
             pLevel_Player->Action_Jump(true);
 	    
             //Move the player up a little bit so that they don't instantaneously stomp on a pip
-            pLevel_Player->m_pos_y -= 5;
+            pLevel_Player->m_pos_y -= 10;
             pLevel_Player->Update_Position_Rect();
 
             // It is very hard to not get hit by the two resulting small pips. Thus,

--- a/tsc/src/enemies/pip.cpp
+++ b/tsc/src/enemies/pip.cpp
@@ -151,11 +151,13 @@ void cPip::DownGrade(bool force /* = false */)
         if (m_state == STA_WALK) { // Split big up into two small ones
             Set_Moving_State(STA_RUN);
 
-            // Spawn a second pip so it looks as if cut in twice
+            int big_pip_width = m_images[0].m_image->m_col_w; //Image width of a big pip
+
+            // Spawn a second pip so it looks as if cut in two
             cPip* p_newpip = Copy();
             p_newpip->Set_Spawned(true); // Do not save into level file when editor is activated + saved!
             p_newpip->Set_Moving_State(STA_RUN);
-            p_newpip->m_pos_x = m_pos_x + 75;
+            p_newpip->m_pos_x = m_pos_x + big_pip_width / 2; //Stay within bounds of original big pip
             p_newpip->m_pos_y = m_pos_y;
 
             //We just changed pips' positions.  Update the collision rectangles accordingly.

--- a/tsc/src/enemies/pip.cpp
+++ b/tsc/src/enemies/pip.cpp
@@ -297,7 +297,6 @@ void cPip::Handle_Collision_Player(cObjectCollision* p_collision)
         if (m_state == STA_WALK) {
             DownGrade();
             pLevel_Player->Action_Jump(true);
-            pLevel_Player->m_pos_x += 15; // Ensure the player does not get stuck on one of the small pips
 	    
 	    //Shoot the player up a bit but not too much - this helps prevent him from immediately stomping on a small pip
             pLevel_Player->m_vely = -30.0f;

--- a/tsc/src/enemies/pip.cpp
+++ b/tsc/src/enemies/pip.cpp
@@ -150,22 +150,19 @@ void cPip::DownGrade(bool force /* = false */)
     else {
         if (m_state == STA_WALK) { // Split big up into two small ones
             Set_Moving_State(STA_RUN);
-            Col_Move(m_images[10].m_image->m_col_w - m_images[0].m_image->m_col_w, 0.0f, true, true);
 
             // Spawn a second pip so it looks as if cut in twice
             cPip* p_newpip = Copy();
             p_newpip->Set_Spawned(true); // Do not save into level file when editor is activated + saved!
             p_newpip->Set_Moving_State(STA_RUN);
-            p_newpip->m_pos_x = m_pos_x;
+            p_newpip->m_pos_x = m_pos_x + 75;
             p_newpip->m_pos_y = m_pos_y;
 
             // Accelerate us up-left
-            m_pos_y -= 5.0f;
             m_velx = -15.0f;
             m_vely = -15.0f;
 
             // Accelerate the new one up-right
-            p_newpip->m_pos_y -= 60;
             p_newpip->m_velx = 15.0f; // Opposite direction than above!
             p_newpip->m_vely = -15.0f;
             m_sprite_manager->Add(p_newpip);
@@ -301,6 +298,9 @@ void cPip::Handle_Collision_Player(cObjectCollision* p_collision)
             DownGrade();
             pLevel_Player->Action_Jump(true);
             pLevel_Player->m_pos_x += 15; // Ensure the player does not get stuck on one of the small pips
+	    
+	    //Shoot the player up a bit but not too much - this helps prevent him from immediately stomping on a small pip
+            pLevel_Player->m_vely = -30.0f;
 
             // It is very hard to not get hit by the two resulting small pips. Thus,
             // grant the player a short period of invincibility.
@@ -310,7 +310,7 @@ void cPip::Handle_Collision_Player(cObjectCollision* p_collision)
         else if (m_state == STA_RUN) { // small walking
             DownGrade();
             pLevel_Player->Add_Kill_Multiplier();
-            // Whoooohooooo!
+            // Whoooohooooo!  Shoot the player up high!
             pLevel_Player->m_vely = -60.0f;
             pAudio->Play_Sound("player/jump_big_power.ogg");
         }

--- a/tsc/src/enemies/pip.cpp
+++ b/tsc/src/enemies/pip.cpp
@@ -158,6 +158,10 @@ void cPip::DownGrade(bool force /* = false */)
             p_newpip->m_pos_x = m_pos_x + 75;
             p_newpip->m_pos_y = m_pos_y;
 
+            //We just changed pips' positions.  Update the collision rectangles accordingly.
+            Update_Position_Rect();
+            p_newpip ->Update_Position_Rect();
+
             // Accelerate us up-left
             m_velx = -15.0f;
             m_vely = -15.0f;

--- a/tsc/src/enemies/pip.cpp
+++ b/tsc/src/enemies/pip.cpp
@@ -302,8 +302,9 @@ void cPip::Handle_Collision_Player(cObjectCollision* p_collision)
             DownGrade();
             pLevel_Player->Action_Jump(true);
 	    
-	    //Shoot the player up a bit but not too much - this helps prevent him from immediately stomping on a small pip
-            pLevel_Player->m_vely = -30.0f;
+            //Move the player up a little bit so that they don't instantaneously stomp on a pip
+            pLevel_Player->m_pos_y -= 5;
+            pLevel_Player->Update_Position_Rect();
 
             // It is very hard to not get hit by the two resulting small pips. Thus,
             // grant the player a short period of invincibility.


### PR DESCRIPTION
This fix is designed to fix the following 4 bugs when Big Pips are stomped:
* Spawned small pips getting stuck in a wall to the left
* Small pips getting stuck in each other (it is intended to reduce the likelihood of this)
* Alex getting stuck in a pip
* A small pip hovering above the ground wiggling back and forth before finally falling to the ground (due to collision boxes not being updated)

If Alex stomps near the center of the Big Pip, the two small pips will normally shoot out to the right and left.  If Alex stomps to the extreme left or right of a Big Pip, he is likely to instantaneously stomp a small pip (do an "autostomp").  An autostomp near the edges is expected behavior for this change.

The only issue I have found is the following:
* If my laptop is plugged in, everything behaves exactly as I intended it.
* If my laptop is unplugged (which slows the speed of about everything to save power), it becomes more likely that Alex will "autostomp" on one of the small pips.  I did not observe this difference in behavior for unplugging my laptop while testing against the current release-2.0.0 code.  This suggests a difference in behavior based on CPU speed.

Honestly, the 4 bugs above are very noticeable to players, so even if there is a different amount of "autostomp" based on CPU speed, we may still be better of merging this.  We can always continue to play with the pip code.

@Quintus / @Luiji / @brianvanderburg2 / @sydneyjd -- If any of you can check out the code from the PipWallStuckFixB branch and give it a test it would be appreciated.  I'd suggest going ahead and purging your build directory and rebuilding before testing.

Also, I have not pulled the latest release-2.0.0 changes into this branch, since if I do it with a rebase, it will refuse to let me push to this branch, citing a possible loss of history.