### PR TITLE
Fix 335 sublevel scripting

### DIFF
--- a/tsc/src/level/level.hpp
+++ b/tsc/src/level/level.hpp
@@ -179,6 +179,8 @@ namespace TSC {
         cSprite_Manager* m_sprite_manager;
         // MRuby interpreter used for this level
         Scripting::cMRuby_Interpreter* m_mruby;
+        // Do not re-Init() on sublevel loading.
+        bool m_mruby_has_been_initialized;
 
         /* *** *** *** Settings *** *** *** *** */
 

--- a/tsc/src/scripting/scriptable_object.cpp
+++ b/tsc/src/scripting/scriptable_object.cpp
@@ -13,9 +13,30 @@
  */
 
 #include "scriptable_object.hpp"
+#include "../level/level.hpp"
+#include "../core/property_helper.hpp"
 
 using namespace TSC;
 using namespace TSC::Scripting;
+
+/* The `m_callbacks' member variable of the cScriptableObject class
+ * is blasphemical currently. It holds mruby objects (mrb_value instances)
+ * of DIFFERENT mruby interpreters! The reason for this is sublevel
+ * handling. Each level has its own mruby interpreter attached, but
+ * while the sublevel is active, mruby handlers from the outer
+ * main level are “suspended” and should not be run. Problem is,
+ * some objects, most notably the level player (cLevel_Player singleton
+ * instance), is shared amongst all currently active levels. This is
+ * a design flaw that should probably be fixed, but to work around
+ * the problem m_callbacks just maps an event handler by both level
+ * and event name. If you tried to run an event handler from a level
+ * different from the active one (pActive_Level), this would actually
+ * work and have effect on the currently invisible level. However, this
+ * is unintended and not allowed by the outbound interface of the
+ * cScriptable_Object class hence. When a sublevel is destroyed, it
+ * is required to remove all objects it has from the `m_callbacks'
+ * member by employing clear_event_handlers() with its level name
+ * passed. */
 
 cScriptable_Object::cScriptable_Object()
 {
@@ -38,15 +59,31 @@ cScriptable_Object::~cScriptable_Object()
  * to segmentation faults when an event gets fired for which an
  * event handler has been registered prior to deleting the mruby
  * interpreter.
+ *
+ * This method may also be used to just wipe out the event handlers for
+ * a specific level by passing the parameter `levelname`. This situation
+ * can arise if you are dealing with sublevels, where more than one level
+ * can be loaded at a time.
+ *
+ * \param[in] level ("") level to clear. If an empty string, all event
+ * handlers for all levels a cleared. If the level you want to clear
+ * the event handlers for is ~/.local/share/tsc/foo.tsclvl, then you
+ * pass in `"foo"` for this parameter. A user and a game level of the
+ * same name cannot be loaded at the same time, so this is not a
+ * problem here.
  */
-void cScriptable_Object::clear_event_handlers()
+void cScriptable_Object::clear_event_handlers(const std::string& levelname /* = "" */)
 {
-    m_callbacks.clear();
+    if (levelname.empty())
+        m_callbacks.clear();
+    else
+        m_callbacks[levelname].clear();
 }
 
 /**
- * Register a new event handler for an event, adding to the list of already
- * existing event handlers (if any).
+ * Register a new event handler for an event for the currently active
+ * level, adding to the list of already existing event handlers (if
+ * any).
  *
  * \param evtname
  *   Name of the event to register for. This has to match a return value
@@ -57,7 +94,7 @@ void cScriptable_Object::clear_event_handlers()
  */
 void cScriptable_Object::register_event_handler(const std::string& evtname, mrb_value callback)
 {
-    m_callbacks[evtname].push_back(callback);
+    m_callbacks[get_active_level_name()][evtname].push_back(callback);
 }
 
 /**
@@ -70,7 +107,7 @@ void cScriptable_Object::register_event_handler(const std::string& evtname, mrb_
  */
 std::vector<mrb_value>::iterator cScriptable_Object::event_handlers_begin(const std::string& evtname)
 {
-    return m_callbacks[evtname].begin();
+    return m_callbacks[get_active_level_name()][evtname].begin();
 }
 
 /**
@@ -83,5 +120,10 @@ std::vector<mrb_value>::iterator cScriptable_Object::event_handlers_begin(const 
  */
 std::vector<mrb_value>::iterator cScriptable_Object::event_handlers_end(const std::string& evtname)
 {
-    return m_callbacks[evtname].end();
+    return m_callbacks[get_active_level_name()][evtname].end();
+}
+
+std::string cScriptable_Object::get_active_level_name()
+{
+    return path_to_utf8(pActive_Level->m_level_filename.stem());
 }

--- a/tsc/src/scripting/scriptable_object.hpp
+++ b/tsc/src/scripting/scriptable_object.hpp
@@ -29,14 +29,18 @@ namespace TSC {
             cScriptable_Object();
             virtual ~cScriptable_Object();
 
-            void clear_event_handlers();
+            void clear_event_handlers(const std::string& levelname = "");
             void register_event_handler(const std::string& evtname, mrb_value callback);
             std::vector<mrb_value>::iterator event_handlers_begin(const std::string& evtname);
             std::vector<mrb_value>::iterator event_handlers_end(const std::string& evtname);
 
         protected:
-            /// Mapping of event names and registered callbacks.
-            std::map<std::string, std::vector<mrb_value> > m_callbacks;
+            /// Mapping of level + event names and registered callbacks.
+            /// Example in ruby syntax:
+            /// {"mylevel" => {"myevent" => [handle1, handle2]}, "mevent2" => ["handle3"]}
+            std::map<std::string, std::map<std::string, std::vector<mrb_value> > > m_callbacks;
+        private:
+            std::string get_active_level_name();
         };
     };
 };

--- a/tsc/src/scripting/scripting.cpp
+++ b/tsc/src/scripting/scripting.cpp
@@ -100,15 +100,18 @@ cMRuby_Interpreter::~cMRuby_Interpreter()
     /* When the mruby interpreter gets deleted, all remaining mruby objects
      * (mrb_value instances) are invalidated. Therefore, we wipe all the
      * existing event callbacks here. */
+    std::string levelname = path_to_utf8(pActive_Level->m_level_filename.stem());
     cSprite_List::iterator iter;
     for (iter = mp_level->m_sprite_manager->objects.begin(); iter != mp_level->m_sprite_manager->objects.end(); iter++) {
         cSprite* p_sprite = *iter;
-        p_sprite->clear_event_handlers();
+        p_sprite->clear_event_handlers(levelname); // Would probably work fine without the level name (→ total clearing) as these sprites do not live longer than the level itself anyway
     }
-    pAudio->clear_event_handlers();
-    pKeyboard->clear_event_handlers();
-    pSavegame->clear_event_handlers();
-    pLevel_Player->clear_event_handlers();
+    // These objects stay alive even though a level ends. Only wipe those
+    // handlers for our own level.
+    pAudio->clear_event_handlers(levelname);
+    pKeyboard->clear_event_handlers(levelname);
+    pSavegame->clear_event_handlers(levelname);
+    pLevel_Player->clear_event_handlers(levelname);
 
     // Get all the registered timers from mruby
     mrb_value klass = mrb_obj_value(mrb_class_get(mp_mruby, "Timer"));


### PR DESCRIPTION
This is to fix ticket #335 (bad sublevel scripting behaviour). The problem was twofold:

1. The event handlers were not tied to the level name, so that it was possible to mix up event handlers from different levels loaded at one time. They would actually be executed in the currently disabled level. Very confusing. This PR fixes that by tieing the event handlers to both the level and the event name.
2. The design of `cLevel` if flawed because the `Init()` method is public which it shouldn’t be. It is called from the outside at some unpredictable places (such as when returning from a sublevel), and each time it erased and reinstanciated the mruby interpreter. This PR adds a switch to detect whether the interpreter was already initialised and skips redoing the initialisation of the interpreter if that is detected.

Number 2 above is a rather hacky solution, but the proper solution requires some big restructuring due to the `Init()` all over the codebase. Probably requires rewriting of the entire sublevel loading.

@SonOfBowser, could you please test if these changes fix the problem you have reported in #335?

Reviewing the change by others of course is also appreciated.

Valete,
Quintus