### PR TITLE
Support Reverse Compatibility of .smclvl and .smcsav files...

### DIFF
--- a/tsc/src/gui/menu_data.cpp
+++ b/tsc/src/gui/menu_data.cpp
@@ -558,15 +558,18 @@ void cMenu_Start::Get_Levels(fs::path dir, CEGUI::colour color)
     CEGUI::Listbox* listbox_levels = static_cast<CEGUI::Listbox*>(CEGUI::WindowManager::getSingleton().getWindow("listbox_levels"));
 
     // get all files
+    // .tsclvl is the new TSC level format, but .smclvl is listed for reverse compatibility
     vector<fs::path> lvl_files = Get_Directory_Files(dir, ".tsclvl", false, false);
+    vector<fs::path> lvl_files2 = Get_Directory_Files(dir, ".smclvl", false, false);
+    lvl_files.insert(lvl_files.end(), lvl_files2.begin(), lvl_files2.end());
 
     // list all available levels
     for (vector<fs::path>::iterator itr = lvl_files.begin(); itr != lvl_files.end(); ++itr) {
         // get filename without base directory
         fs::path lvl_path = (*itr).filename();
 
-        // erase file extension only if tsclvl
-        if (lvl_path.extension() == fs::path(".tsclvl"))
+        // erase file extension only if tsclvl or smclvl (reverse compatibilty)
+        if (lvl_path.extension() == fs::path(".tsclvl") || lvl_path.extension() == fs::path(".smclvl"))
             lvl_path = lvl_path.stem();
 
         // create listbox item

--- a/tsc/src/level/level.cpp
+++ b/tsc/src/level/level.cpp
@@ -195,11 +195,11 @@ cLevel* cLevel::Load_From_File(fs::path filename)
     // This is our loader
     cLevelLoader loader;
 
-    // new level format
-    if (filename.extension() == fs::path(".tsclvl")) {
+    // supported level format
+    if (filename.extension() == fs::path(".tsclvl")  || filename.extension() == fs::path(".smclvl")) {
         loader.parse_file(filename);
     }
-    else { // old level format
+    else { // old, unsupported level format
         pHud_Debug->Set_Text(_("Unsupported Level format : ") + (const std::string)path_to_utf8(filename));
         return NULL;
     }

--- a/tsc/src/level/level.cpp
+++ b/tsc/src/level/level.cpp
@@ -356,8 +356,12 @@ void cLevel::Save(void)
         m_level_filename = fs::absolute(m_level_filename, pResource_Manager->Get_User_Level_Directory());
     }
 
+    //Force all levels to save with the .tsclvl extension
+    fs::path tsc_level_filename = m_level_filename;
+    tsc_level_filename.replace_extension(".tsclvl");
+
     try {
-        Save_To_File(m_level_filename);
+        Save_To_File(tsc_level_filename);
     }
     catch (xmlpp::exception& e) {
         std::cerr << "Error: Couldn't save level file: " << e.what() << std::endl;
@@ -366,6 +370,15 @@ void cLevel::Save(void)
 
         // Abort
         return;
+    }
+
+    //If the file originally had .smclvl for the extension and if the .tsclvl save was successful, remove the old
+    //.smclvl file.
+    if (m_level_filename.extension().string() == ".smclvl") {
+        if (fs::exists(m_level_filename) && fs::exists(tsc_level_filename)) {
+            fs::remove(m_level_filename);
+        }
+        m_level_filename.replace_extension(".tsclvl");
     }
 
     // Display nice completion message

--- a/tsc/src/level/level_manager.cpp
+++ b/tsc/src/level/level_manager.cpp
@@ -164,7 +164,7 @@ fs::path cLevel_Manager::Get_Path(const std::string& levelname, bool check_only_
 
     // user level directory as default
     fs::path user_filename = fs::absolute(filename, pResource_Manager->Get_User_Level_Directory());
-    // use new file type as default
+    // use new TSC file type as default
     user_filename.replace_extension(".tsclvl");
 
     if (File_Exists(user_filename)) {
@@ -172,7 +172,15 @@ fs::path cLevel_Manager::Get_Path(const std::string& levelname, bool check_only_
         return user_filename;
     }
 
-    // use old file type
+    // use old SMC file type
+    user_filename.replace_extension(".smclvl");
+
+    if (File_Exists(user_filename)) {
+        // found
+        return user_filename;
+    }
+
+    // use very old file type
     user_filename.replace_extension(".txt");
 
     if (File_Exists(user_filename)) {
@@ -181,9 +189,10 @@ fs::path cLevel_Manager::Get_Path(const std::string& levelname, bool check_only_
     }
 
     if (!check_only_user_dir) {
+        //Next try the game data directory
         fs::path game_filename = fs::absolute(filename, pResource_Manager->Get_Game_Level_Directory());
 
-        // use new file type
+        // use new TSC file type
         game_filename.replace_extension(".tsclvl");
 
         if (File_Exists(game_filename)) {
@@ -191,7 +200,15 @@ fs::path cLevel_Manager::Get_Path(const std::string& levelname, bool check_only_
             return game_filename;
         }
 
-        // use old file type
+        // use old SMC file type
+        game_filename.replace_extension(".smclvl");
+
+        if (File_Exists(game_filename)) {
+            // found
+            return game_filename;
+        }
+
+        // use very old file type
         game_filename.replace_extension(".txt");
 
         if (File_Exists(game_filename)) {

--- a/tsc/src/overworld/overworld.cpp
+++ b/tsc/src/overworld/overworld.cpp
@@ -728,7 +728,7 @@ cWaypoint* cOverworld::Get_Waypoint(unsigned int num)
 int cOverworld::Get_Level_Waypoint_Num(std::string level_name)
 {
     // erase file type if set
-    if (level_name.rfind(".txt") != std::string::npos || level_name.rfind(".tsclvl") != std::string::npos) {
+    if (level_name.rfind(".txt") != std::string::npos || level_name.rfind(".smclvl") != std::string::npos || level_name.rfind(".tsclvl") != std::string::npos) {
         level_name.erase(level_name.rfind("."));
     }
 

--- a/tsc/src/user/savegame.cpp
+++ b/tsc/src/user/savegame.cpp
@@ -755,8 +755,9 @@ bool cSavegame::Save_Game(unsigned int save_slot, std::string description)
     }
 
     fs::path filename = m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".tscsav");
-    // remove old format savegame
+    // remove old format savegame files
     fs::remove(m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".save"));
+    fs::remove(m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".smclvl"));
 
     try {
         savegame->Write_To_File(filename);

--- a/tsc/src/user/savegame.cpp
+++ b/tsc/src/user/savegame.cpp
@@ -786,18 +786,24 @@ cSave* cSavegame::Load(unsigned int save_slot)
     if (File_Exists(filename)) {
         savegame = cSave::Load_From_File(filename);
     }
-    else
-    {
-        //If it is not in the newer format, try the older format
-        fs::path filename_old = m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".save");
-        if (File_Exists(filename_old)) {
-            savegame = cSave::Load_From_File(filename_old);
+    else {
+        //If it is not in the newer tscsav format, try the older .smcsav format
+        fs::path filename_smc = m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".smcsav");
+        if (File_Exists(filename_smc)) {
+            savegame = cSave::Load_From_File(filename_smc);
         }
         else {
-            //There is not a file in any useful format -- throw an exception
-            std::stringstream ss;
-            ss << "No savegame found at slot " << save_slot << " (filename '" << filename << "' or '" << filename_old << "')!";
-            throw(InvalidSavegameError(save_slot, ss.str()));
+            //If it is not in the other two formats, try the very old .save format
+            fs::path filename_old = m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".save");
+            if (File_Exists(filename_old)) {
+                savegame = cSave::Load_From_File(filename_old);
+            }
+            else {
+                //There is not a file in any useful format -- throw an exception
+                std::stringstream ss;
+                ss << "No savegame found at slot " << save_slot << " (filename '" << filename << "' or '" << filename_old << "')!";
+                throw(InvalidSavegameError(save_slot, ss.str()));
+            }
         }
     }
 
@@ -873,7 +879,8 @@ std::string cSavegame::Get_Description(unsigned int save_slot, bool only_descrip
 
 bool cSavegame::Is_Valid(unsigned int save_slot) const
 {
-    return (File_Exists(m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".tscsav")) || File_Exists(m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".save")));
+    return (File_Exists(m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".tscsav")) || File_Exists(m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".smcsav")) ||
+            File_Exists(m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".save")));
 }
 
 cSavegame* pSavegame = NULL;

--- a/tsc/src/user/savegame.cpp
+++ b/tsc/src/user/savegame.cpp
@@ -757,7 +757,7 @@ bool cSavegame::Save_Game(unsigned int save_slot, std::string description)
     fs::path filename = m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".tscsav");
     // remove old format savegame files
     fs::remove(m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".save"));
-    fs::remove(m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".smclvl"));
+    fs::remove(m_savegame_dir / utf8_to_path(int_to_string(save_slot) + ".smcsav"));
 
     try {
         savegame->Write_To_File(filename);

--- a/tsc/src/user/savegame_loader.cpp
+++ b/tsc/src/user/savegame_loader.cpp
@@ -49,7 +49,8 @@ void cSavegameLoader::parse_file(fs::path filename)
 {
     m_savefile = filename;
 
-    m_is_old_format = m_savefile.extension() == utf8_to_path(".tscsav") ? false : true;
+    //Note: If changes are made to the .tscsav format but not the .smcsav format, the below logic will need to change
+    m_is_old_format = m_savefile.extension() == utf8_to_path(".tscsav") || m_savefile.extension() == utf8_to_path(".smcsav") ? false : true;
 
     xmlpp::SaxParser::parse_file(path_to_utf8(filename));
 }


### PR DESCRIPTION
This change:
*Allows loading of .smclvl files (old format level files)
*Saves level files as .tsclvl
    *For the Save option if the old file was .smclvl, the .smclvl file is deleted and a .tsclvl file is saved, renaming it)
    *The "Save As" option for levels will not delete a corresponding .smclvl file -- this is since any file name could be entered.    
*Allows loading of .smcsav files (old format save state files)
*Saves save state files as .tscsav (the corresponding .smcsav file will be deleted, as used to be done for .save files)

Also:
*Reverse compatibility is not needed for worlds for this change -- they do not have smc or tsc in their file names
*Reverse compatibility is not implemented for campaign files.  The user cannot create new campaigns without manually editing xml, and I have never seen a campaign file posted on the forums before.

Please review this change.
Also, the 4th commit in this branch was mostly based on code analysis by eye -- some of those changes cannot easily be tested.



