### PR TITLE
Implemented a game reset action.

### DIFF
--- a/tsc/src/core/game_core.cpp
+++ b/tsc/src/core/game_core.cpp
@@ -44,6 +44,7 @@ namespace TSC {
 /* *** *** *** *** *** *** *** *** Variables *** *** *** *** *** *** *** *** *** */
 
 bool game_exit = 0;
+bool game_reset = 0;
 GameMode Game_Mode = MODE_NOTHING;
 GameModeType Game_Mode_Type = MODE_TYPE_DEFAULT;
 GameAction Game_Action = GA_NONE;
@@ -109,6 +110,10 @@ void Handle_Game_Events(void)
             level_exit->Activate();
             Handle_Generic_Game_Events(current_game_action_data_middle);
             Handle_Generic_Game_Events(current_game_action_data_end);
+        }
+        // reset
+        else if(current_game_action == GA_RESET) {
+            game_reset = 1;
         }
         // full events
         else {

--- a/tsc/src/core/game_core.hpp
+++ b/tsc/src/core/game_core.hpp
@@ -27,6 +27,8 @@ namespace TSC {
 
 // quit game if true
     extern bool game_exit;
+// reset game if true
+    extern bool game_reset;
 // current Game Mode
     extern GameMode Game_Mode;
 // current Game Mode Type

--- a/tsc/src/core/global_game.hpp
+++ b/tsc/src/core/global_game.hpp
@@ -116,7 +116,8 @@ namespace TSC {
         GA_ENTER_LEVEL      = 3,
         GA_DOWNGRADE_PLAYER = 4,
         GA_ACTIVATE_LEVEL_EXIT  = 5,
-        GA_ENTER_LEVEL_SETTINGS = 6
+        GA_ENTER_LEVEL_SETTINGS = 6,
+        GA_RESET                = 7
     };
 
     /* *** *** *** *** *** Level draw type *** *** *** *** *** *** *** *** *** *** *** *** */

--- a/tsc/src/core/main.cpp
+++ b/tsc/src/core/main.cpp
@@ -172,50 +172,60 @@ int main(int argc, char** argv)
         }
     }
 
-    // initialize everything
-    Init_Game();
+    do {
+        game_reset = false;
+        game_exit = false;
 
-    // command line level entering
-    if (argc > 2 && (arguments[1] == "--level" || arguments[1] == "-l") && !arguments[2].empty()) {
-        Game_Action = GA_ENTER_LEVEL;
-        Game_Mode_Type = MODE_TYPE_LEVEL_CUSTOM;
-        Game_Action_Data_Middle.add("load_level", arguments[2]);
-    }
-    // command line world entering
-    else if (argc > 2 && (arguments[1] == "--world" || arguments[1] == "-w") && !arguments[2].empty()) {
-        Game_Action = GA_ENTER_WORLD;
-        Game_Action_Data_Middle.add("enter_world", arguments[2]);
-    }
-    // enter main menu
-    else {
-        Game_Action = GA_ENTER_MENU;
-        Game_Action_Data_Middle.add("load_menu", int_to_string(MENU_MAIN));
-    }
+        // initialize everything
+        Init_Game();
 
-    Game_Action_Data_Start.add("screen_fadeout", CEGUI::PropertyHelper::intToString(EFFECT_OUT_BLACK));
-    Game_Action_Data_Start.add("screen_fadeout_speed", "3");
-    Game_Action_Data_End.add("screen_fadein", CEGUI::PropertyHelper::intToString(EFFECT_IN_BLACK));
-    Game_Action_Data_End.add("screen_fadein_speed", "3");
+        // command line level entering
+        if (argc > 2 && (arguments[1] == "--level" || arguments[1] == "-l") && !arguments[2].empty()) {
+            Game_Action = GA_ENTER_LEVEL;
+            Game_Mode_Type = MODE_TYPE_LEVEL_CUSTOM;
+            Game_Action_Data_Middle.add("load_level", arguments[2]);
+        }
+        // command line world entering
+        else if (argc > 2 && (arguments[1] == "--world" || arguments[1] == "-w") && !arguments[2].empty()) {
+            Game_Action = GA_ENTER_WORLD;
+            Game_Action_Data_Middle.add("enter_world", arguments[2]);
+        }
+        // enter main menu
+        else {
+            Game_Action = GA_ENTER_MENU;
+            Game_Action_Data_Middle.add("load_menu", int_to_string(MENU_MAIN));
+        }
 
-    // game loop
-    while (!game_exit) {
-        // update
-        Update_Game();
-        // draw
-        Draw_Game();
+        Game_Action_Data_Start.add("screen_fadeout", CEGUI::PropertyHelper::intToString(EFFECT_OUT_BLACK));
+        Game_Action_Data_Start.add("screen_fadeout_speed", "3");
+        Game_Action_Data_End.add("screen_fadein", CEGUI::PropertyHelper::intToString(EFFECT_IN_BLACK));
+        Game_Action_Data_End.add("screen_fadein_speed", "3");
 
-        // render
+        // game loop
+        while (!game_exit and !game_reset) {
+            // update
+            Update_Game();
+            // draw
+            Draw_Game();
+
+            // render
 #ifdef TSC_RENDER_THREAD_TEST
-        pVideo->Render(1);
+            pVideo->Render(1);
 #else
-        pVideo->Render();
+            pVideo->Render();
 #endif
 
-        // update speedfactor
-        pFramerate->Update();
-    }
+            // update speedfactor
+            pFramerate->Update();
+        }
 
-    Exit_Game();
+        Exit_Game();
+ 
+        // reset should start fresh, so reset package, level, and world
+        g_cmdline_package = "";
+        argc = 0;
+
+    } while (game_reset);
     return EXIT_SUCCESS;
 }
 

--- a/tsc/src/gui/menu_data.cpp
+++ b/tsc/src/gui/menu_data.cpp
@@ -647,6 +647,7 @@ void cMenu_Start::Load_Package(std::string name)
 
     pPreferences->m_package = name;
     pPreferences->Save();
+    Game_Action = GA_RESET;
 }
 
 void cMenu_Start::Load_Campaign(std::string name)


### PR DESCRIPTION
This commit create a new game action, GA_RESET, which will result in the reset of the game.  The reset will also reset any command line parameters such as --level and --world (basically sets argc =0), so it doesn't go right into the level or world after a reset..

A game_reset flag is introduced, and in main.cpp a loop has been created which goes through the Init_Game, stuff, Exit_Game as long as game_reset is true.  It is set to false at the top of each cycle, so something in the game has to set it to true to initiate a reset.  This does a complete reset by freeing up resources/sdl/etc, then initializing them again.

The main reason I implemented this was so switching packages would not require quitting and restarting the program.  Since the choice of a package can override graphics entirely from base packages, changing the package needs a way to ensure that everything is released so using the package will be sure to use the correct resources.  This reset mechanism does just that.  This also means the command line option for a package can probably be removed.