### PR TITLE
Refactoring save code.

### DIFF
--- a/tsc/src/enemies/army.cpp
+++ b/tsc/src/enemies/army.cpp
@@ -128,7 +128,7 @@ void cArmy::Load_From_Savegame(cSave_Level_Object* save_object)
     }
 }
 
-cSave_Level_Object* cArmy::Save_To_Savegame(void)
+cSave_Level_Object* cArmy::Save_To_Savegame(bool force/*=true*/)
 {
     cSave_Level_Object* save_object = cEnemy::Save_To_Savegame();
 

--- a/tsc/src/enemies/army.hpp
+++ b/tsc/src/enemies/army.hpp
@@ -60,7 +60,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object);
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Set Direction
         virtual void Set_Direction(const ObjectDirection dir, bool new_start_direction = 0);

--- a/tsc/src/enemies/enemy.cpp
+++ b/tsc/src/enemies/enemy.cpp
@@ -64,40 +64,7 @@ cEnemy::~cEnemy(void)
 
 void cEnemy::Load_From_Savegame(cSave_Level_Object* save_object)
 {
-    // state
-    if (save_object->exists("state")) {
-        m_state = static_cast<Moving_state>(string_to_int(save_object->Get_Value("state")));
-    }
-
-    // new position x
-    if (save_object->exists("new_posx")) {
-        Set_Pos_X(string_to_float(save_object->Get_Value("new_posx")));
-    }
-
-    // new position y
-    if (save_object->exists("new_posy")) {
-        Set_Pos_Y(string_to_float(save_object->Get_Value("new_posy")));
-    }
-
-    // direction
-    if (save_object->exists("direction")) {
-        m_direction = static_cast<ObjectDirection>(string_to_int(save_object->Get_Value("direction")));
-    }
-
-    // velocity x
-    if (save_object->exists("velx")) {
-        m_velx = string_to_float(save_object->Get_Value("velx"));
-    }
-
-    // velocity y
-    if (save_object->exists("vely")) {
-        m_vely = string_to_float(save_object->Get_Value("vely"));
-    }
-
-    // active
-    if (save_object->exists("active")) {
-        Set_Active(string_to_int(save_object->Get_Value("active")) > 0);
-    }
+    cMovingSprite::Load_From_Savegame(save_object);
 
     // dead
     if (save_object->exists("dead")) {
@@ -105,37 +72,9 @@ void cEnemy::Load_From_Savegame(cSave_Level_Object* save_object)
     }
 }
 
-cSave_Level_Object* cEnemy::Save_To_Savegame(void)
+cSave_Level_Object* cEnemy::Save_To_Savegame(bool force/*=true*/)
 {
-    cSave_Level_Object* save_object = new cSave_Level_Object();
-
-    // default values
-    save_object->m_type = m_type;
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posx", int_to_string(static_cast<int>(m_start_pos_x))));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posy", int_to_string(static_cast<int>(m_start_pos_y))));
-
-
-
-    // state
-    save_object->m_properties.push_back(cSave_Level_Object_Property("state", int_to_string(m_state)));
-
-    // new position ( only save if needed )
-    if (!Is_Float_Equal(m_start_pos_x, m_pos_x) || !Is_Float_Equal(m_start_pos_y, m_pos_y)) {
-        save_object->m_properties.push_back(cSave_Level_Object_Property("new_posx", int_to_string(static_cast<int>(m_pos_x))));
-        save_object->m_properties.push_back(cSave_Level_Object_Property("new_posy", int_to_string(static_cast<int>(m_pos_y))));
-    }
-
-    // direction
-    save_object->m_properties.push_back(cSave_Level_Object_Property("direction", int_to_string(m_direction)));
-
-    // velocity
-    save_object->m_properties.push_back(cSave_Level_Object_Property("velx", float_to_string(m_velx)));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("vely", float_to_string(m_vely)));
-
-    // active ( only save if needed )
-    if (!m_active) {
-        save_object->m_properties.push_back(cSave_Level_Object_Property("active", int_to_string(m_active)));
-    }
+    cSave_Level_Object* save_object = cMovingSprite::Save_To_Savegame();
 
     // dead ( only save if needed )
     if (m_dead) {

--- a/tsc/src/enemies/enemy.hpp
+++ b/tsc/src/enemies/enemy.hpp
@@ -37,7 +37,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object);
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Create the MRuby object for this
         virtual mrb_value Create_MRuby_Object(mrb_state* p_state)

--- a/tsc/src/enemies/flyon.cpp
+++ b/tsc/src/enemies/flyon.cpp
@@ -131,7 +131,7 @@ void cFlyon::Load_From_Savegame(cSave_Level_Object* save_object)
     }
 }
 
-cSave_Level_Object* cFlyon::Save_To_Savegame(void)
+cSave_Level_Object* cFlyon::Save_To_Savegame(bool force/*=true*/)
 {
     cSave_Level_Object* save_object = cEnemy::Save_To_Savegame();
 

--- a/tsc/src/enemies/flyon.hpp
+++ b/tsc/src/enemies/flyon.hpp
@@ -42,7 +42,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object);
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Create the MRuby object for this
         virtual mrb_value Create_MRuby_Object(mrb_state* p_state)

--- a/tsc/src/enemies/spikeball.cpp
+++ b/tsc/src/enemies/spikeball.cpp
@@ -101,7 +101,6 @@ xmlpp::Element* cSpikeball::Save_To_XML_Node(xmlpp::Element* p_element)
 
 void cSpikeball::Load_From_Savegame(cSave_Level_Object* save_object)
 {
-    cerr << "Loading Spikeball\n";
     cEnemy::Load_From_Savegame(save_object);
 
     Update_Rotation_Hor();

--- a/tsc/src/enemies/spikeball.cpp
+++ b/tsc/src/enemies/spikeball.cpp
@@ -101,6 +101,7 @@ xmlpp::Element* cSpikeball::Save_To_XML_Node(xmlpp::Element* p_element)
 
 void cSpikeball::Load_From_Savegame(cSave_Level_Object* save_object)
 {
+    cerr << "Loading Spikeball\n";
     cEnemy::Load_From_Savegame(save_object);
 
     Update_Rotation_Hor();

--- a/tsc/src/enemies/static.cpp
+++ b/tsc/src/enemies/static.cpp
@@ -148,7 +148,7 @@ void cStaticEnemy::Load_From_Savegame(cSave_Level_Object* save_object)
     m_path_state.Load_From_Savegame(save_object);
 }
 
-cSave_Level_Object* cStaticEnemy::Save_To_Savegame(void)
+cSave_Level_Object* cStaticEnemy::Save_To_Savegame(bool force/*=true*/)
 {
     cSave_Level_Object* save_object = cEnemy::Save_To_Savegame();
     m_path_state.Save_To_Savegame(save_object);

--- a/tsc/src/enemies/static.hpp
+++ b/tsc/src/enemies/static.hpp
@@ -57,7 +57,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object);
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Set the rotation speed
         void Set_Rotation_Speed(float speed);

--- a/tsc/src/enemies/thromp.cpp
+++ b/tsc/src/enemies/thromp.cpp
@@ -137,7 +137,7 @@ void cThromp::Load_From_Savegame(cSave_Level_Object* save_object)
     }
 }
 
-cSave_Level_Object* cThromp::Save_To_Savegame(void)
+cSave_Level_Object* cThromp::Save_To_Savegame(bool force/*=true*/)
 {
     cSave_Level_Object* save_object = cEnemy::Save_To_Savegame();
 

--- a/tsc/src/enemies/thromp.hpp
+++ b/tsc/src/enemies/thromp.hpp
@@ -49,7 +49,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object);
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Set the image directory. `dir' must be relative to the pixmaps/ directory.
         void Set_Image_Dir(boost::filesystem::path dir);

--- a/tsc/src/objects/ball.cpp
+++ b/tsc/src/objects/ball.cpp
@@ -119,51 +119,12 @@ xmlpp::Element* cBall::Save_To_XML_Node(xmlpp::Element* p_element)
 
 void cBall::Load_From_Savegame(cSave_Level_Object* save_object)
 {
-    // new position x
-    if (save_object->exists("new_posx")) {
-        Set_Pos_X(string_to_float(save_object->Get_Value("new_posx")));
-    }
-
-    // new position y
-    if (save_object->exists("new_posy")) {
-        Set_Pos_Y(string_to_float(save_object->Get_Value("new_posy")));
-    }
-
-    // direction
-    if (save_object->exists("direction")) {
-        m_direction = static_cast<ObjectDirection>(string_to_int(save_object->Get_Value("direction")));
-    }
-
-    // velocity x
-    if (save_object->exists("velx")) {
-        m_velx = string_to_float(save_object->Get_Value("velx"));
-    }
-
-    // velocity y
-    if (save_object->exists("vely")) {
-        m_vely = string_to_float(save_object->Get_Value("vely"));
-    }
+    cMovingSprite::Load_From_Savegame(save_object);
 }
 
-cSave_Level_Object* cBall::Save_To_Savegame(void)
+cSave_Level_Object* cBall::Save_To_Savegame(bool force/*=true*/)
 {
-    cSave_Level_Object* save_object = new cSave_Level_Object();
-
-    // default values
-    save_object->m_type = m_type;
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posx", int_to_string(static_cast<int>(m_start_pos_x))));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posy", int_to_string(static_cast<int>(m_start_pos_y))));
-
-    // new position
-    save_object->m_properties.push_back(cSave_Level_Object_Property("new_posx", int_to_string(static_cast<int>(m_pos_x))));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("new_posy", int_to_string(static_cast<int>(m_pos_y))));
-
-    // direction
-    save_object->m_properties.push_back(cSave_Level_Object_Property("direction", int_to_string(m_direction)));
-
-    // velocity
-    save_object->m_properties.push_back(cSave_Level_Object_Property("velx", float_to_string(m_velx)));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("vely", float_to_string(m_vely)));
+    cSave_Level_Object* save_object = cMovingSprite::Save_To_Savegame();
 
     return save_object;
 }

--- a/tsc/src/objects/ball.hpp
+++ b/tsc/src/objects/ball.hpp
@@ -41,7 +41,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object);
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Create the MRuby object for this
         virtual mrb_value Create_MRuby_Object(mrb_state* p_state)

--- a/tsc/src/objects/box.cpp
+++ b/tsc/src/objects/box.cpp
@@ -126,22 +126,20 @@ void cBaseBox::Load_From_Savegame(cSave_Level_Object* save_object)
     Set_Useable_Count(save_useable_count);
 }
 
-cSave_Level_Object* cBaseBox::Save_To_Savegame(void)
+cSave_Level_Object* cBaseBox::Save_To_Savegame(bool force/*=true*/)
 {
     // only save if needed
-    if (m_useable_count == m_start_useable_count) {
+    bool needsave = m_useable_count != m_start_useable_count;
+    if(!needsave && !force) {
         return NULL;
     }
 
-    cSave_Level_Object* save_object = new cSave_Level_Object();
+    cSave_Level_Object* save_object = cMovingSprite::Save_To_Savegame();
 
-    // default values
-    save_object->m_type = m_type;
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posx", int_to_string(static_cast<int>(m_start_pos_x))));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posy", int_to_string(static_cast<int>(m_start_pos_y))));
-
-    // Useable Count
-    save_object->m_properties.push_back(cSave_Level_Object_Property("useable_count", int_to_string(m_useable_count)));
+    // Useable Count only if needed
+    if(needsave) {
+        save_object->m_properties.push_back(cSave_Level_Object_Property("useable_count", int_to_string(m_useable_count)));
+    }
 
     return save_object;
 }

--- a/tsc/src/objects/box.hpp
+++ b/tsc/src/objects/box.hpp
@@ -50,7 +50,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object);
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Create the MRuby object for this
         virtual mrb_value Create_MRuby_Object(mrb_state* p_state)

--- a/tsc/src/objects/crate.cpp
+++ b/tsc/src/objects/crate.cpp
@@ -96,13 +96,9 @@ void cCrate::Load_From_Savegame(cSave_Level_Object* p_saveobj)
     }
 }
 
-cSave_Level_Object* cCrate::Save_To_Savegame(void)
+cSave_Level_Object* cCrate::Save_To_Savegame(bool force/*=true*/)
 {
-    cSave_Level_Object* p_saveobj = new cSave_Level_Object();
-
-    p_saveobj->m_type = m_type;
-    p_saveobj->m_properties.push_back(cSave_Level_Object_Property("posx", int_to_string(static_cast<int>(m_start_pos_x))));
-    p_saveobj->m_properties.push_back(cSave_Level_Object_Property("posy", int_to_string(static_cast<int>(m_start_pos_y))));
+    cSave_Level_Object* p_saveobj = cMovingSprite::Save_To_Savegame();
 
     p_saveobj->m_properties.push_back(cSave_Level_Object_Property("state", int_to_string(m_state)));
 

--- a/tsc/src/objects/crate.hpp
+++ b/tsc/src/objects/crate.hpp
@@ -39,7 +39,7 @@ namespace TSC {
         virtual ~cCrate();
 
         virtual void Load_From_Savegame(cSave_Level_Object* p_save_object);
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Create the MRuby object for this
         virtual mrb_value Create_MRuby_Object(mrb_state* p_state)

--- a/tsc/src/objects/goldpiece.cpp
+++ b/tsc/src/objects/goldpiece.cpp
@@ -89,41 +89,12 @@ xmlpp::Element* cGoldpiece::Save_To_XML_Node(xmlpp::Element* p_element)
 
 void cGoldpiece::Load_From_Savegame(cSave_Level_Object* save_object)
 {
-    // new position x
-    if (save_object->exists("new_posx")) {
-        Set_Pos_X(string_to_float(save_object->Get_Value("new_posx")));
-    }
-
-    // new position y
-    if (save_object->exists("new_posy")) {
-        Set_Pos_Y(string_to_float(save_object->Get_Value("new_posy")));
-    }
-
-    // active
-    if (save_object->exists("active")) {
-        Set_Active(string_to_int(save_object->Get_Value("active")) > 0);
-    }
+    cMovingSprite::Load_From_Savegame(save_object);
 }
 
-cSave_Level_Object* cGoldpiece::Save_To_Savegame(void)
+cSave_Level_Object* cGoldpiece::Save_To_Savegame(bool force/*=true*/)
 {
-    cSave_Level_Object* save_object = new cSave_Level_Object();
-
-    // default values
-    save_object->m_type = m_type;
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posx", int_to_string(static_cast<int>(m_start_pos_x))));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posy", int_to_string(static_cast<int>(m_start_pos_y))));
-
-    // new position ( only save if needed )
-    if (!Is_Float_Equal(m_start_pos_x, m_pos_x) || !Is_Float_Equal(m_start_pos_y, m_pos_y)) {
-        save_object->m_properties.push_back(cSave_Level_Object_Property("new_posx", int_to_string(static_cast<int>(m_pos_x))));
-        save_object->m_properties.push_back(cSave_Level_Object_Property("new_posy", int_to_string(static_cast<int>(m_pos_y))));
-    }
-
-    // active
-    if (!m_active) {
-        save_object->m_properties.push_back(cSave_Level_Object_Property("active", int_to_string(m_active)));
-    }
+    cSave_Level_Object* save_object = cMovingSprite::Save_To_Savegame();
 
     return save_object;
 }

--- a/tsc/src/objects/goldpiece.hpp
+++ b/tsc/src/objects/goldpiece.hpp
@@ -52,7 +52,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object);
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Set the gold color
         virtual void Set_Gold_Color(DefaultColor color);

--- a/tsc/src/objects/moving_platform.cpp
+++ b/tsc/src/objects/moving_platform.cpp
@@ -228,74 +228,23 @@ void cMoving_Platform::Set_Sprite_Manager(cSprite_Manager* sprite_manager)
 
 void cMoving_Platform::Load_From_Savegame(cSave_Level_Object* save_object)
 {
-    // direction
-    if (save_object->exists("direction")) {
-        m_direction = static_cast<ObjectDirection>(string_to_int(save_object->Get_Value("direction")));
-    }
+    cMovingSprite::Load_From_Savegame(save_object);
 
     // platform state
     if (save_object->exists("platform_state")) {
         m_platform_state = static_cast<Moving_Platform_State>(string_to_int(save_object->Get_Value("platform_state")));
     }
 
-    // new position x
-    if (save_object->exists("new_posx")) {
-        Set_Pos_X(string_to_float(save_object->Get_Value("new_posx")));
-    }
-
-    // new position y
-    if (save_object->exists("new_posy")) {
-        Set_Pos_Y(string_to_float(save_object->Get_Value("new_posy")));
-    }
-
-    // velocity x
-    if (save_object->exists("velx")) {
-        m_velx = string_to_float(save_object->Get_Value("velx"));
-    }
-
-    // velocity y
-    if (save_object->exists("vely")) {
-        m_vely = string_to_float(save_object->Get_Value("vely"));
-    }
-
-    // active
-    if (save_object->exists("active")) {
-        Set_Active(string_to_int(save_object->Get_Value("active")) > 0);
-    }
-
     // path state
     m_path_state.Load_From_Savegame(save_object);
 }
 
-cSave_Level_Object* cMoving_Platform::Save_To_Savegame(void)
+cSave_Level_Object* cMoving_Platform::Save_To_Savegame(bool force/*=true*/)
 {
-    cSave_Level_Object* save_object = new cSave_Level_Object();
-
-    // default values
-    save_object->m_type = m_type;
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posx", int_to_string(static_cast<int>(m_start_pos_x))));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posy", int_to_string(static_cast<int>(m_start_pos_y))));
-
-    // direction
-    save_object->m_properties.push_back(cSave_Level_Object_Property("direction", int_to_string(m_direction)));
+    cSave_Level_Object* save_object = cMovingSprite::Save_To_Savegame();
 
     // platform state
     save_object->m_properties.push_back(cSave_Level_Object_Property("platform_state", int_to_string(m_platform_state)));
-
-    // new position ( only save if needed )
-    if (m_start_pos_x != m_pos_x || m_start_pos_y != m_pos_y) {
-        save_object->m_properties.push_back(cSave_Level_Object_Property("new_posx", int_to_string(static_cast<int>(m_pos_x))));
-        save_object->m_properties.push_back(cSave_Level_Object_Property("new_posy", int_to_string(static_cast<int>(m_pos_y))));
-    }
-
-    // velocity
-    save_object->m_properties.push_back(cSave_Level_Object_Property("velx", float_to_string(m_velx)));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("vely", float_to_string(m_vely)));
-
-    // active ( only save if needed )
-    if (!m_active) {
-        save_object->m_properties.push_back(cSave_Level_Object_Property("active", int_to_string(m_active)));
-    }
 
     // path state
     m_path_state.Save_To_Savegame(save_object);

--- a/tsc/src/objects/moving_platform.hpp
+++ b/tsc/src/objects/moving_platform.hpp
@@ -78,7 +78,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object);
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Set move type
         void Set_Move_Type(Moving_Platform_Type move_type);

--- a/tsc/src/objects/movingsprite.cpp
+++ b/tsc/src/objects/movingsprite.cpp
@@ -20,6 +20,7 @@
 #include "../core/game_core.hpp"
 #include "../level/level.hpp"
 #include "../user/preferences.hpp"
+#include "../user/savegame.hpp"
 #include "../audio/audio.hpp"
 #include "../level/level_player.hpp"
 #include "../enemies/army.hpp"
@@ -53,6 +54,76 @@ cMovingSprite::cMovingSprite(XmlAttributes& attributes, cSprite_Manager* sprite_
 cMovingSprite::~cMovingSprite(void)
 {
     //
+}
+
+void cMovingSprite::Load_From_Savegame(cSave_Level_Object* save_object)
+{
+    cSprite::Load_From_Savegame(save_object);
+
+    // state
+    if (save_object->exists("state")) {
+        m_state = static_cast<Moving_state>(string_to_int(save_object->Get_Value("state")));
+    }
+
+    // new position x
+    if (save_object->exists("new_posx")) {
+        Set_Pos_X(string_to_float(save_object->Get_Value("new_posx")));
+    }
+
+    // new position y
+    if (save_object->exists("new_posy")) {
+        Set_Pos_Y(string_to_float(save_object->Get_Value("new_posy")));
+    }
+
+    // direction
+    if (save_object->exists("direction")) {
+        m_direction = static_cast<ObjectDirection>(string_to_int(save_object->Get_Value("direction")));
+    }
+
+    // velocity x
+    if (save_object->exists("velx")) {
+        m_velx = string_to_float(save_object->Get_Value("velx"));
+    }
+
+    // velocity y
+    if (save_object->exists("vely")) {
+        m_vely = string_to_float(save_object->Get_Value("vely"));
+    }
+
+    // active
+    if (save_object->exists("active")) {
+        Set_Active(string_to_int(save_object->Get_Value("active")) > 0);
+    }
+}
+
+cSave_Level_Object* cMovingSprite::Save_To_Savegame(bool force/*=true*/)
+{
+    cSave_Level_Object* save_object = cSprite::Save_To_Savegame();
+
+    // state
+    save_object->m_properties.push_back(cSave_Level_Object_Property("state", int_to_string(m_state)));
+
+    // new position ( only save if needed )
+    if (!Is_Float_Equal(m_start_pos_x, m_pos_x) || !Is_Float_Equal(m_start_pos_y, m_pos_y)) {
+        save_object->m_properties.push_back(cSave_Level_Object_Property("new_posx", int_to_string(static_cast<int>(m_pos_x))));
+        save_object->m_properties.push_back(cSave_Level_Object_Property("new_posy", int_to_string(static_cast<int>(m_pos_y))));
+    }
+
+    // direction
+    save_object->m_properties.push_back(cSave_Level_Object_Property("direction", int_to_string(m_direction)));
+
+    // velocity (only if needed)
+    if(!Is_Float_Equal(m_velx, 0.0) || !Is_Float_Equal(m_vely, 0.0)) {
+        save_object->m_properties.push_back(cSave_Level_Object_Property("velx", float_to_string(m_velx)));
+        save_object->m_properties.push_back(cSave_Level_Object_Property("vely", float_to_string(m_vely)));
+    }
+
+    // active ( only save if needed )
+    if (!m_active) {
+        save_object->m_properties.push_back(cSave_Level_Object_Property("active", int_to_string(m_active)));
+    }
+
+    return save_object;
 }
 
 void cMovingSprite::Init(void)

--- a/tsc/src/objects/movingsprite.hpp
+++ b/tsc/src/objects/movingsprite.hpp
@@ -65,6 +65,11 @@ namespace TSC {
         // destructor
         virtual ~cMovingSprite(void);
 
+        // load from save game
+        virtual void Load_From_Savegame(cSave_Level_Object* save_object);
+        // save to save game
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
+
         // Init defaults
         void Init(void);
         // copy this object

--- a/tsc/src/objects/path.cpp
+++ b/tsc/src/objects/path.cpp
@@ -529,14 +529,9 @@ void cPath::Load_From_Savegame(cSave_Level_Object* save_object)
 
 }
 
-cSave_Level_Object* cPath::Save_To_Savegame(void)
+cSave_Level_Object* cPath::Save_To_Savegame(bool force/*=true*/)
 {
-    cSave_Level_Object* save_object = new cSave_Level_Object();
-
-    // default values
-    save_object->m_type = m_type;
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posx", int_to_string(static_cast<int>(m_start_pos_x))));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posy", int_to_string(static_cast<int>(m_start_pos_y))));
+    cSave_Level_Object* save_object = cSprite::Save_To_Savegame();
 
     return save_object;
 }

--- a/tsc/src/objects/path.hpp
+++ b/tsc/src/objects/path.hpp
@@ -158,7 +158,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object);
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Create the MRuby object for this
         virtual mrb_value Create_MRuby_Object(mrb_state* p_state)

--- a/tsc/src/objects/powerup.cpp
+++ b/tsc/src/objects/powerup.cpp
@@ -53,63 +53,12 @@ cPowerUp::~cPowerUp(void)
 
 void cPowerUp::Load_From_Savegame(cSave_Level_Object* save_object)
 {
-    // new position x
-    if (save_object->exists("new_posx")) {
-        Set_Pos_X(string_to_float(save_object->Get_Value("new_posx")));
-    }
-
-    // new position y
-    if (save_object->exists("new_posy")) {
-        Set_Pos_Y(string_to_float(save_object->Get_Value("new_posy")));
-    }
-
-    // direction
-    if (save_object->exists("direction")) {
-        m_direction = static_cast<ObjectDirection>(string_to_int(save_object->Get_Value("direction")));
-    }
-
-    // velocity x
-    if (save_object->exists("velx")) {
-        m_velx = string_to_float(save_object->Get_Value("velx"));
-    }
-
-    // velocity y
-    if (save_object->exists("vely")) {
-        m_vely = string_to_float(save_object->Get_Value("vely"));
-    }
-
-    // active
-    if (save_object->exists("active")) {
-        Set_Active(string_to_int(save_object->Get_Value("active")) > 0);
-    }
+    cMovingSprite::Load_From_Savegame(save_object);
 }
 
-cSave_Level_Object* cPowerUp::Save_To_Savegame(void)
+cSave_Level_Object* cPowerUp::Save_To_Savegame(bool force/*=true*/)
 {
-    cSave_Level_Object* save_object = new cSave_Level_Object();
-
-    // default values
-    save_object->m_type = m_type;
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posx", int_to_string(static_cast<int>(m_start_pos_x))));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posy", int_to_string(static_cast<int>(m_start_pos_y))));
-
-    // new position ( only save if needed )
-    if (!Is_Float_Equal(m_start_pos_x, m_pos_x) || !Is_Float_Equal(m_start_pos_y, m_pos_y)) {
-        save_object->m_properties.push_back(cSave_Level_Object_Property("new_posx", int_to_string(static_cast<int>(m_pos_x))));
-        save_object->m_properties.push_back(cSave_Level_Object_Property("new_posy", int_to_string(static_cast<int>(m_pos_y))));
-    }
-
-    // direction
-    save_object->m_properties.push_back(cSave_Level_Object_Property("direction", int_to_string(m_direction)));
-
-    // velocity
-    save_object->m_properties.push_back(cSave_Level_Object_Property("velx", float_to_string(m_velx)));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("vely", float_to_string(m_vely)));
-
-    // active
-    if (!m_active) {
-        save_object->m_properties.push_back(cSave_Level_Object_Property("active", int_to_string(m_active)));
-    }
+    cSave_Level_Object* save_object = cMovingSprite::Save_To_Savegame();
 
     return save_object;
 }

--- a/tsc/src/objects/powerup.hpp
+++ b/tsc/src/objects/powerup.hpp
@@ -39,7 +39,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object);
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Create the MRuby object for this
         virtual mrb_value Create_MRuby_Object(mrb_state* p_state)

--- a/tsc/src/objects/spinbox.cpp
+++ b/tsc/src/objects/spinbox.cpp
@@ -90,28 +90,17 @@ void cSpinBox::Load_From_Savegame(cSave_Level_Object* save_object)
     }
 }
 
-cSave_Level_Object* cSpinBox::Save_To_Savegame(void)
+cSave_Level_Object* cSpinBox::Save_To_Savegame(bool force/*=true*/)
 {
-    if(!m_spin)
+    if(!m_spin && !force)
         return NULL;
-
-    /* HACK:
-     * This is a hack to force cBaseBox to save. We need a "force" option for Save_To_Savegame
-     * We make sure the usable count and start count differ so it saves by changing the start
-     * count since it saves the useable count. */
-    int original_count = m_start_useable_count;
-    m_start_useable_count = m_useable_count + 1;
 
     cSave_Level_Object* save_object = cBaseBox::Save_To_Savegame();
-    m_start_useable_count = original_count; // Restore original start count
-
-    if(save_object == NULL) {
-        // oh well, can't save spin counter
-        return NULL;
-    }
 
     // spin counter
-    save_object->m_properties.push_back(cSave_Level_Object_Property("spin_counter", float_to_string(m_spin_counter)));
+    if(m_spin) {
+        save_object->m_properties.push_back(cSave_Level_Object_Property("spin_counter", float_to_string(m_spin_counter)));
+    }
 
     return save_object;
 }

--- a/tsc/src/objects/spinbox.hpp
+++ b/tsc/src/objects/spinbox.hpp
@@ -46,7 +46,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object);
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void);
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         // Create the MRuby object for this
         virtual mrb_value Create_MRuby_Object(mrb_state* p_state)

--- a/tsc/src/objects/sprite.cpp
+++ b/tsc/src/objects/sprite.cpp
@@ -526,14 +526,18 @@ xmlpp::Element* cSprite::Save_To_XML_Node(xmlpp::Element* p_element)
  */
 cSave_Level_Object* cSprite::Save_To_Savegame(bool force /*=true*/)
 {
-    // default values
-    cSave_Level_Object* save_object = new cSave_Level_Object();
+    if(force) {
+        cSave_Level_Object* save_object = new cSave_Level_Object();
 
-    save_object->m_type = m_type;
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posx", int_to_string(static_cast<int>(m_start_pos_x))));
-    save_object->m_properties.push_back(cSave_Level_Object_Property("posy", int_to_string(static_cast<int>(m_start_pos_y))));
+        // default values
+        save_object->m_type = m_type;
+        save_object->m_properties.push_back(cSave_Level_Object_Property("posx", int_to_string(static_cast<int>(m_start_pos_x))));
+        save_object->m_properties.push_back(cSave_Level_Object_Property("posy", int_to_string(static_cast<int>(m_start_pos_y))));
 
-    return save_object;
+        return save_object;
+    } else {
+        return NULL;
+    }
 }
 
 /**

--- a/tsc/src/objects/sprite.cpp
+++ b/tsc/src/objects/sprite.cpp
@@ -33,6 +33,7 @@
 #include "../core/filesystem/package_manager.hpp"
 #include "../core/xml_attributes.hpp"
 #include "../core/global_basic.hpp"
+#include "../user/savegame.hpp"
 
 using namespace std;
 
@@ -516,6 +517,23 @@ xmlpp::Element* cSprite::Save_To_XML_Node(xmlpp::Element* p_element)
         Add_Property(p_node, "type", type);
 
     return p_node;
+}
+
+/**
+ * This method saves the node to a savegame.
+ *
+ * \param force Force creating a node
+ */
+cSave_Level_Object* cSprite::Save_To_Savegame(bool force /*=true*/)
+{
+    // default values
+    cSave_Level_Object* save_object = new cSave_Level_Object();
+
+    save_object->m_type = m_type;
+    save_object->m_properties.push_back(cSave_Level_Object_Property("posx", int_to_string(static_cast<int>(m_start_pos_x))));
+    save_object->m_properties.push_back(cSave_Level_Object_Property("posy", int_to_string(static_cast<int>(m_start_pos_y))));
+
+    return save_object;
 }
 
 /**

--- a/tsc/src/objects/sprite.hpp
+++ b/tsc/src/objects/sprite.hpp
@@ -138,10 +138,7 @@ namespace TSC {
         // load from savegame
         virtual void Load_From_Savegame(cSave_Level_Object* save_object) {};
         // save to savegame
-        virtual cSave_Level_Object* Save_To_Savegame(void)
-        {
-            return NULL;
-        };
+        virtual cSave_Level_Object* Save_To_Savegame(bool force=true);
 
         /// Sets the image for drawing
         virtual void Set_Image(cGL_Surface* new_image, bool new_start_image = 0, bool del_img = 0);

--- a/tsc/src/user/savegame.cpp
+++ b/tsc/src/user/savegame.cpp
@@ -679,8 +679,8 @@ bool cSavegame::Save_Game(unsigned int save_slot, std::string description)
             for (cSprite_List::iterator itr = level->m_sprite_manager->objects.begin(); itr != level->m_sprite_manager->objects.end(); ++itr) {
                 cSprite* obj = (*itr);
 
-                // get save data
-                cSave_Level_Object* save_obj = obj->Save_To_Savegame();
+                // get save data, but don't force if it doesn't need to be saved
+                cSave_Level_Object* save_obj = obj->Save_To_Savegame(false);
 
                 // nothing to save
                 if (!save_obj) {


### PR DESCRIPTION
I've refactored the save code for saving level objects, as mentioned in #186.  This allows for reducing a lot of duplication.

Note:  I've tested loading a save game based on level bad_evening, and some items are not loading from the saved game.  However, after stashing the changes and recompiling directly from devel, the same problem occurs, so that bug is apparently not related to this patch but from somewhere else.

Message similar to the following:
```
Warning : Savegame object type 52 on x 3003, y -1243 not available
Warning : Savegame object type 31 on x 6508, y -541 not available
```