### PR TITLE
Vanderburg animation fixes1

### DIFF
--- a/tsc/src/video/img_set.cpp
+++ b/tsc/src/video/img_set.cpp
@@ -81,8 +81,14 @@ bool cImageSet::Parser::HandleMessage(const std::string* parts, unsigned int cou
         {
             if(*it == "..")
             {
-                // TODO: make sure there is a parent path
-                info.m_filename = info.m_filename.parent_path();
+                if(!info.m_filename.empty()) {
+                    info.m_filename = info.m_filename.parent_path();
+                } else {
+                    cerr << "Warning: path '" << utf8_to_path(parts[0])
+                         << "' referenced from '" << data_file
+                         << "' false outside of pixmap search paths" << endl;
+                    return 1; // don't abort parsing, just continue with next line skipping this frame
+                }
             }
             else
             {

--- a/tsc/src/video/img_set.cpp
+++ b/tsc/src/video/img_set.cpp
@@ -150,7 +150,7 @@ int cImageSet::Surface::Leave(void)
     if(m_info.m_branches.size() == 0)
         return -1;
 
-    int rnd = rand() % 101;
+    int rnd = (rand() % 100) + 1; // 1 to 100 inclusive
     for(FrameInfo::List_Type::iterator it = m_info.m_branches.begin(); it != m_info.m_branches.end(); ++it)
     {
         // first is frame number, second is percentage

--- a/tsc/src/video/img_set.cpp
+++ b/tsc/src/video/img_set.cpp
@@ -258,6 +258,12 @@ bool cImageSet::Set_Image_Set(const std::string& name, bool new_startimage /* =0
         Set_Animation((end > start)); // True if more than one image
         Reset_Animation();
 
+        // Enter in Update_Animation only calls after leaving the current
+        // frame, so we need to call the initial Enter here.
+        if(start >= 0 && start <= static_cast<int>(m_images.size())) {
+            m_images[start].Enter();
+        }
+
         return true;
     }
 }

--- a/tsc/src/video/img_set.hpp
+++ b/tsc/src/video/img_set.hpp
@@ -48,11 +48,13 @@ namespace TSC {
             typedef std::vector<FrameInfo> List_Type;
 
             Parser(Uint32 time);
+            bool Parse(const boost::filesystem::path& filename);
             bool HandleMessage(const std::string* parts, unsigned int count, unsigned int line);
 
             List_Type m_images;
             Uint32 m_time_min;
             Uint32 m_time_max;
+            boost::filesystem::path relative_data_file;
         };
 
         /* *** *** *** *** *** *** *** Surface *** *** *** *** *** *** *** *** *** *** */


### PR DESCRIPTION
This provides two fixes to the animation code:
* Normally, the first frame is not entered. Upate_Animation only calls Enter after it leaves one frame and changes to the next.  This means with an array of ground sprites using image sets with random times, the first frame will display the minimum time instead of a random time.  The fix I used is to call Enter for the first frame inside of Set_Image_Set
* The next change makes it where an image set can reference files anywhere along the package search path instead of relative to the location of the image set file.  I could create a package, then add an image set under my pixmaps path somewhere, but reference images directly in the base data without having to copy the files into my package.  The commit comment explains it best.

Basically, if my image set file is /package1/pixmaps/something/my.imgset, then it is treated relatively as something/my.imgset.  Then if an image reference is used such as ../blocks/ice/1.png, it gets combined as something/../blocks/ice/1.png, then normalized as blocks/ice/1.png, so the package manager can use any path to find blocks/ice/1.png