### PR TITLE
Vanderburg load fix

### DIFF
--- a/tsc/src/enemies/spika.cpp
+++ b/tsc/src/enemies/spika.cpp
@@ -101,7 +101,7 @@ void cSpika::Set_Color(DefaultColor col)
     }
 
     // clear old images
-    Clear_Images();
+    Clear_Images(true);
 
     m_color_type = col;
 

--- a/tsc/src/enemies/static.cpp
+++ b/tsc/src/enemies/static.cpp
@@ -55,7 +55,7 @@ cStaticEnemy::cStaticEnemy(XmlAttributes& attributes, cSprite_Manager* sprite_ma
 
     // image
     m_image_filename = attributes.fetch("image", m_image_filename); // Init sets m_image_filename default
-    Clear_Images();
+    Clear_Images(true);
     Add_Image_Set("main", utf8_to_path(m_image_filename));
     Set_Image_Set("main", true);
 
@@ -89,7 +89,7 @@ void cStaticEnemy::Init(void)
     Set_Speed(0.0f);
 
     m_image_filename = "enemy/static/blocks/spike_1/2_grey.png";
-    Clear_Images();
+    Clear_Images(true);
     Add_Image_Set("main", utf8_to_path(m_image_filename));
     Set_Image_Set("main", true);
 }
@@ -104,7 +104,7 @@ cStaticEnemy* cStaticEnemy::Copy(void) const
 {
     cStaticEnemy* static_enemy = new cStaticEnemy(m_sprite_manager);
     static_enemy->Set_Pos(m_start_pos_x, m_start_pos_y, 1);
-    static_enemy->Clear_Images();
+    static_enemy->Clear_Images(true);
     static_enemy->m_image_filename = m_image_filename;
     static_enemy->Add_Image_Set("main", utf8_to_path(m_image_filename));
     static_enemy->Set_Image_Set("main", true);
@@ -365,7 +365,7 @@ bool cStaticEnemy::Editor_Image_Text_Changed(const CEGUI::EventArgs& event)
     const CEGUI::WindowEventArgs& windowEventArgs = static_cast<const CEGUI::WindowEventArgs&>(event);
     std::string str_text = static_cast<CEGUI::Editbox*>(windowEventArgs.window)->getText().c_str();
 
-    Clear_Images();
+    Clear_Images(true);
     m_image_filename = str_text;
     Add_Image_Set("main", utf8_to_path(m_image_filename));
     Set_Image_Set("main", true);

--- a/tsc/src/objects/moving_platform.cpp
+++ b/tsc/src/objects/moving_platform.cpp
@@ -429,6 +429,7 @@ void cMoving_Platform::Set_Image_Top_Left(const fs::path& path)
     m_left_image.Clear_Images();
     m_left_image.Add_Image_Set("main", path);
     m_left_image.Set_Image_Set("main");
+    Clear_Images(true);
     Set_Image(m_left_image.m_image, 1);
 
     Update_Rect();

--- a/tsc/src/objects/powerup.cpp
+++ b/tsc/src/objects/powerup.cpp
@@ -275,7 +275,7 @@ void cMushroom::Set_Type(SpriteType new_type)
     }
 
     Set_Color_Combine(0, 0, 0, 0);
-    Clear_Images();
+    Clear_Images(true);
 
     if (new_type == TYPE_MUSHROOM_DEFAULT) {
         Add_Image_Set("main", "game/items/berry_big.imgset");
@@ -500,7 +500,7 @@ void cFirePlant::Init(void)
     m_can_be_on_ground = 0;
     m_pos_z = 0.051f;
 
-    Clear_Images();
+    Clear_Images(true);
     Add_Image_Set("main", "game/items/berry_fire.imgset");
     Set_Image_Set("main", 1);
 
@@ -604,7 +604,7 @@ void cMoon::Init(void)
     m_can_be_on_ground = 0;
     m_pos_z = 0.052f;
 
-    Clear_Images();
+    Clear_Images(true);
     Add_Image_Set("main", "game/items/moon.imgset");
     Set_Image_Set("main", 1);
 


### PR DESCRIPTION
This fixes some loading bugs.  It turns out that during loading, setting an image sometimes results in moving the sprite.  This happens because in cMovingSprite, when an image is set, if there is a current image it tests the difference of the collision rectangles and moves the sprite based on the difference.
```c++
cSomething::cSomething(XMLAttributes attr)
{
    Init(); // #1 sets up the default sprite resulting in a call to Set_Image
    Set_Color(attr["color"]);  // #2 calls Set_Image again, if a difference exists, will move the sprite
}

cSomething::Init()
{
    Set_Color(DEFAULT);
}

cSomething::Set_Color(Color c)
{
    Clear_Images();
    if(c == 1)
    {
        Add_Image(...)
    }
    else if(c == 2)
    {
        Add_Image(...)
    }

   Set_Image_Num(0, 1);
}
```

Essentially what happens is, the call to Init sets up the default color/image and loads an image. Then at position number 2, it sets a different image, and cMovingSprite::Set_Image computes the different and makes an adjustment to the sprite position if needed.  After all this is done (after the level is loaded), the save loading code tries to find the object by position, but since the item has moved it can't find it.

What this change does is it introduces a flag to Clear_Images that also provides the option to clear the current image (m_image).  This way, the next call to Set_Image will not have a current image and so no collision change will exist, the sprite will not be moved.  During level editing and loading, this image should be reset.  During normal game play if there is a reason to call Clear_Images, then it should not clear the current image and allow the moving to occur. (most sprites don't, but I noticed the player object does clear images and load new images when the player's state changes).

This is against the devel branch.  datahead suggested this could also be applied to the release branch.  I think this can be done without any problems.  Most of the code can be applied as is, but instead of cImageSet::Clear_Images, cAnimagedSprite::Clear_Images would have the reset option.

The default option to Clear_Images is false (do not reset m_image to NULL).  There may be other places that have this same issue.  Having the default to true instead of false would probably solve many of them, but may also cause problems in other places if clearing the image list still expects the current image to be valid and not NULL.

This references #378  as well.