### PR TITLE
Improvements to save mechanism

### DIFF
--- a/tsc/src/user/savegame/save_level.cpp
+++ b/tsc/src/user/savegame/save_level.cpp
@@ -101,16 +101,16 @@ void cSave_Level::Save_To_Node(xmlpp::Element* p_parent_node)
     xmlpp::Element* p_objects_data_node = p_node->add_child("objects_data");
     std::vector<const cSprite*>::const_iterator iter;
     for(iter=m_regular_objects.begin(); iter != m_regular_objects.end(); iter++) {
+        xmlpp::Document subdoc;
+        xmlpp::Element* p_object_node = subdoc.create_root_node("object");
         const cSprite* p_sprite = (*iter);
 
-        /* TODO: Have the sprite itself decide whether it wants to be
-         * saved or not by not adding anything to the node and
-         * returning false from Save_To_Savegame_XML_Node(). For now,
-         * just assume TYPE_UNDEFINED sprites, i.e. all static
-         * nonmoving sprites, do not need to be saved. */
-        if (p_sprite->m_type != TYPE_UNDEFINED) {
-            xmlpp::Element* p_object_node = p_objects_data_node->add_child("object");
-            p_sprite->Save_To_Savegame_XML_Node(p_object_node);
+        /* Let the sprite itself decide whether it wants to be saved.
+         * If the virtual method Save_To_Savegame_XML_Node() returns false,
+         * no saving shall be done, the created XML node is ignored and not
+         * used. If the method returns true, we add in the created node. */
+        if (p_sprite->Save_To_Savegame_XML_Node(p_object_node)) {
+            p_objects_data_node->import_node(p_object_node);
         }
     }
     // </objects_data>


### PR DESCRIPTION
This PR includes the changes @brianvanderburg2, @datahead8888 and me have discussed in #376. An external `xmlpp::Element*` is created, which is only added to the actual document if the sprite itself decides that it wants to be saved, by returning `true` from the `cSprite::Save_To_Savegame_XML_Node()` method.

This is a large PR with several submerges. The relevant (merge) commits for better overview are:

* 7759214
* b99cbb2
* 8331d61
* f7edcfc
* dd07c14
* a2407c0
* 1e9058a
* 385dcae

This commit conducts some code cleanup also:

* The large `savegame.cpp` file has been broken up into several files below a `user/savegame` directory.
* The `force` parameter has been removed from saving
* In conjunction with that, box saving has been adapted so no `force` parameter is needed anymore, instead boxes are always saved completely.
* The logo on the title screen, which has previously been referenced in the code by the horrible `Get_from_Position()` method, is now accessed via passing the `cSprite` object around in the menu classes. This was required so that
* `Get_from_Position()` now only accepts a `bool` parameter, has a more clear implementation, and, most importantly, is only called in the level loading process now. This means that it can be directly removed when we switch loading process to something better. The `bool` parameter can also be removed right now, because it isn’t used anywhere.

This PR tries to not break compatibility with the existing crappy save format. Older saves should continue to work, but I have not yet tested that.

Any testing is appreciated.

Valete,
Quintus