### PR TITLE
Fix level loading crash for older levels with moving platforms.

### DIFF
--- a/tsc/src/level/level_loader.cpp
+++ b/tsc/src/level/level_loader.cpp
@@ -727,10 +727,10 @@ std::vector<cSprite*> cLevelLoader::Create_Moving_Platforms_From_XML_Tag(const s
 
     // if V.1.7 and lower : change new slider middle count because start and end image is now half the width
     if (engine_version < 32) {
-        if (!p_moving_platform->m_images.empty()) {
-            if (p_moving_platform->m_images[0].m_image->m_path.compare(pResource_Manager->Get_Game_Pixmap("ground/green_1/slider/1/brown/left.png")) == 0)
+        if ( !(p_moving_platform->m_left_filename.empty() && p_moving_platform->m_middle_filename.empty() && p_moving_platform->m_right_filename.empty())) {
+            if (p_moving_platform->m_left_filename.compare(pResource_Manager->Get_Game_Pixmap("ground/green_1/slider/1/brown/left.png")) == 0)
                 p_moving_platform->Set_Middle_Count(p_moving_platform->m_middle_count + 1);
-            else if (p_moving_platform->m_images[0].m_image->m_path.compare(pResource_Manager->Get_Game_Pixmap("ground/green_1/slider/1/brown/right.png")) == 0)
+            else if (p_moving_platform->m_left_filename.compare(pResource_Manager->Get_Game_Pixmap("ground/green_1/slider/1/brown/right.png")) == 0)
                 p_moving_platform->Set_Middle_Count(p_moving_platform->m_middle_count + 1);
         }
     }
@@ -772,9 +772,9 @@ std::vector<cSprite*> cLevelLoader::Create_Falling_Platforms_From_XML_Tag(const 
 
     // if V.1.7 and lower : change new slider middle count because start and end image is now half the width
     if (engine_version < 32) {
-        if (p_moving_platform->m_images[0].m_image->m_path.compare(pResource_Manager->Get_Game_Pixmap("ground/green_1/slider/1/brown/left.png")) == 0)
+        if (p_moving_platform->m_left_filename.compare(pResource_Manager->Get_Game_Pixmap("ground/green_1/slider/1/brown/left.png")) == 0)
             p_moving_platform->Set_Middle_Count(p_moving_platform->m_middle_count + 1);
-        else if (p_moving_platform->m_images[0].m_image->m_path.compare(pResource_Manager->Get_Game_Pixmap("ground/green_1/slider/1/brown/right.png")) == 0)
+        else if (p_moving_platform->m_left_filename.compare(pResource_Manager->Get_Game_Pixmap("ground/green_1/slider/1/brown/right.png")) == 0)
             p_moving_platform->Set_Middle_Count(p_moving_platform->m_middle_count + 1);
     }
 


### PR DESCRIPTION
The level loading issue in cave_1 (and maybe other levels) is that the compatibility code is attempting to access the m_images attribute of the moving platform.  This can cause a segmentation fault if the m_images[0] is null or if len(m_images) is 0.  Also, the moving platform no longer uses m_images, but instead three cSimpleImageSet objects to allow using the image sets for moving platforms.

This is a trivial fix, but I wanted to discuss this before committing because while m_images[0] would be the left image from the old code, I notice that the check is testing for right.png, so should the second part of the test be changed to test for m_right_filename instead of m_left_filename when testing against the right.png files?