### PR TITLE
use utf-8 encoding file commands in Rakefile

### DIFF
--- a/tsc/Rakefile
+++ b/tsc/Rakefile
@@ -19,7 +19,7 @@ require "pathname"
 
 CLOBBER.include("build", "crossbuild", "docs/scripting/html", "docs/scripting/rdoc", "docs/api")
 
-str = File.read("CMakeLists.txt")
+str = File.read("CMakeLists.txt", :encoding => "utf-8")
 TSC_VERSION_MAJOR = str.match(/^set\(TSC_VERSION_MAJOR (\d+)\)/)[1]
 TSC_VERSION_MINOR = str.match(/^set\(TSC_VERSION_MINOR (\d+)\)/)[1]
 TSC_VERSION_PATCH = str.match(/^set\(TSC_VERSION_PATCH (\d+)\)/)[1]
@@ -30,7 +30,7 @@ TSC_SOURCE_FILES = FileList["src/**/*.cpp"] + FileList["src/**/*.hpp"]
 rule %r{credits.cpp} => ["docs/authors.txt", "docs/specialthanks.txt"] do |t|
   puts "Converting docs/authors.txt and docs/specialthanks.txt to C++ source file"
 
-  File.open(t.name, "w") do |f|
+  File.open(t.name, "w:utf-8") do |f|
     # Write first part
     f.puts(%Q!#include "#{Dir.pwd}/src/core/global_game.hpp"
 #include "#{Dir.pwd}/src/core/main.hpp"
@@ -39,7 +39,7 @@ namespace TSC {
 
 	const std::string g_credits = "\\\n!)
 
-    File.open("docs/authors.txt") do |f2|
+    File.open("docs/authors.txt", "r:utf-8") do |f2|
       # Skip to real content
       loop do
         line = f2.gets
@@ -58,7 +58,7 @@ namespace TSC {
     f.puts("-- Special Thanks --\\n\\")
     f.puts("\\n\\")
 
-    File.open("docs/specialthanks.txt") do |f2|
+    File.open("docs/specialthanks.txt", "r:utf-8") do |f2|
       # Skip to real content
       loop do
         line = f2.gets


### PR DESCRIPTION
when building in a clean chroot environment (for archlinux) `LANG=C` is set and ruby throws this error
```
rake aborted!
ArgumentError: invalid byte sequence in US-ASCII
/data/Arch/chroot64/koloska/build/tsc-git/src/TSC/tsc/Rakefile:23:in `match'
/data/Arch/chroot64/koloska/build/tsc-git/src/TSC/tsc/Rakefile:23:in `match'
/data/Arch/chroot64/koloska/build/tsc-git/src/TSC/tsc/Rakefile:23:in `<top (required)>'
(See full trace by running task with --trace)
```

I'm no ruby programmer, so maybe it would be better to instead set
```ruby
Encoding.default_external = Encoding::UTF_8
```
in the Rakefile. What do you think?