### PR TITLE
A few fixes for issues found by coverity

### DIFF
--- a/tsc/src/core/framerate.cpp
+++ b/tsc/src/core/framerate.cpp
@@ -74,6 +74,7 @@ cFramerate::cFramerate(void)
     m_max_elapsed_ticks = 100;
     m_speed_factor = 0.1f;
     m_force_speed_factor = 0.0f;
+    m_perf_last_ticks = 0;
 
     // create performance timers
     for (unsigned int i = 0; i < 24; i++) {

--- a/tsc/src/gui/hud.cpp
+++ b/tsc/src/gui/hud.cpp
@@ -653,6 +653,7 @@ cInfoMessage::cInfoMessage(cSprite_Manager* p_sprite_manager)
 
     m_text = "Test";
     m_alpha = -1;
+    m_display_time = 0.0f;
 
     m_background = new cMovingSprite(p_sprite_manager);
     m_background->Set_Ignore_Camera(true);
@@ -1014,7 +1015,7 @@ void cDebugDisplay::Set_Text(const std::string& ntext, float display_time /* = s
 
     if (m_text.empty()) {
         m_text = m_text_old;
-        m_text_old.empty();
+        m_text_old = "";
 
         m_counter = 0;
         return;

--- a/tsc/src/gui/menu_data.cpp
+++ b/tsc/src/gui/menu_data.cpp
@@ -319,7 +319,7 @@ void cMenu_Main::Draw(void)
 cMenu_Start::cMenu_Start(void)
     : cMenu_Base()
 {
-
+    m_listbox_search_buffer_counter = 0.0f;
 }
 
 cMenu_Start::~cMenu_Start(void)

--- a/tsc/src/level/level_loader.cpp
+++ b/tsc/src/level/level_loader.cpp
@@ -62,6 +62,7 @@ cLevelLoader::cLevelLoader()
     : xmlpp::SaxParser()
 {
     mp_level    = NULL;
+    m_in_script_tag = false;
 }
 
 cLevelLoader::~cLevelLoader()


### PR DESCRIPTION
These are very few fixes for issues found by coverity.

Please do the following in Coverity:
- Create components for CEGUI (since a lot of issues are found there) so that we can focus on fixing the core issues first.
- Exclude /usr/include from the scan path.