### PR TITLE
Changed numpad digit key functionality while in world or level editors.

### DIFF
--- a/tsc/src/core/editor/editor.cpp
+++ b/tsc/src/core/editor/editor.cpp
@@ -723,17 +723,27 @@ bool cEditor::Key_Down(SDLKey key)
     }
     // Precise Pixel-Positioning
     else if ((key == pPreferences->m_key_editor_pixel_move_up || key == pPreferences->m_key_editor_pixel_move_down || key == pPreferences->m_key_editor_pixel_move_left || key == pPreferences->m_key_editor_pixel_move_right) && pMouseCursor->m_hovering_object->m_obj) {
+        int x_offset = 0;
+        int y_offset = 0;
+
         if (key == pPreferences->m_key_editor_pixel_move_up) {
-            pActive_Camera->Move(0, -1);
+            y_offset = -1;
         }
         else if (key == pPreferences->m_key_editor_pixel_move_down) {
-            pActive_Camera->Move(0, 1);
+            y_offset = 1;
         }
         else if (key == pPreferences->m_key_editor_pixel_move_left) {
-            pActive_Camera->Move(-1, 0);
+            x_offset = -1;
         }
         else if (key == pPreferences->m_key_editor_pixel_move_right) {
-            pActive_Camera->Move(1, 0);
+            x_offset = 1;
+        }
+
+        for (SelectedObjectList::iterator itr = pMouseCursor->m_selected_objects.begin(); itr != pMouseCursor->m_selected_objects.end(); ++itr) {
+            cSelectedObject* sel_obj = (*itr);
+            cSprite* obj = sel_obj->m_obj;
+
+            obj->Set_Pos(obj->m_pos_x + x_offset, obj->m_pos_y + y_offset, true);
         }
     }
     // deselect everything

--- a/tsc/src/core/editor/editor.cpp
+++ b/tsc/src/core/editor/editor.cpp
@@ -722,7 +722,7 @@ bool cEditor::Key_Down(SDLKey key)
         }
     }
     // Precise Pixel-Positioning
-    else if ((key == pPreferences->m_key_editor_pixel_move_up || key == pPreferences->m_key_editor_pixel_move_down || key == pPreferences->m_key_editor_pixel_move_left || key == pPreferences->m_key_editor_pixel_move_right) && pMouseCursor->m_hovering_object->m_obj) {
+    else if ((key == pPreferences->m_key_editor_pixel_move_up || key == pPreferences->m_key_editor_pixel_move_down || key == pPreferences->m_key_editor_pixel_move_left || key == pPreferences->m_key_editor_pixel_move_right)) {
         int x_offset = 0;
         int y_offset = 0;
 


### PR DESCRIPTION
The numpad digits 2/4/6/8 now move all selected objects one pixel in their respective directions, instead of moving the camera in the opposite direction.

The hope is to mitigate the need to hold the object with a steady hand while moving it. This is nice for people like me who doesn't have steady hands. Also, the image box won't momentarily disappear like it used to.