### PR TITLE
Port mover mode to SFML

### DIFF
--- a/tsc/src/core/editor/editor.cpp
+++ b/tsc/src/core/editor/editor.cpp
@@ -533,11 +533,9 @@ bool cEditor::Handle_Event(const sf::Event& evt)
     switch (evt.type) {
     case sf::Event::MouseMoved: {
         if (pMouseCursor->m_mover_mode) {
-            /* FIXME: SFML does not have relative mouse motion coordinates, we'd need
-             * to store them ourselves to use them here. Ignore this for now. */
-            std::cerr << "FIXME: No relative mouse move coordinates in SFML, can't use mover mode yet!" << std::endl;
-            // Old SDL-based code was:
-            // pMouseCursor->Mover_Update(ev->motion.xrel, ev->motion.yrel);
+            sf::Vector2i pos = sf::Mouse::getPosition();
+
+            pMouseCursor->Mover_Update(pos.x, pos.y);
         }
 
         break;

--- a/tsc/src/core/editor/editor.cpp
+++ b/tsc/src/core/editor/editor.cpp
@@ -812,14 +812,14 @@ bool cEditor::Key_Down(const sf::Event& evt)
     return 1;
 }
 
-bool cEditor::Mouse_Down(Uint8 button)
+bool cEditor::Mouse_Down(sf::Mouse::Button button)
 {
     if (!m_enabled) {
         return 0;
     }
 
     // left
-    if (button == SDL_BUTTON_LEFT) {
+    if (button == sf::Mouse::Left) {
         pMouseCursor->Left_Click_Down();
 
         // auto hide if enabled
@@ -828,7 +828,7 @@ bool cEditor::Mouse_Down(Uint8 button)
         }
     }
     // middle
-    else if (button == SDL_BUTTON_MIDDLE) {
+    else if (button == sf::Mouse::Middle) {
         // Activate fast copy mode
         if (pMouseCursor->m_hovering_object->m_obj) {
             pMouseCursor->m_fastcopy_mode = 1;
@@ -841,7 +841,7 @@ bool cEditor::Mouse_Down(Uint8 button)
         }
     }
     // right
-    else if (button == SDL_BUTTON_RIGHT) {
+    else if (button == sf::Mouse::Right) {
         if (!pMouseCursor->m_left) {
             pMouseCursor->Delete(pMouseCursor->m_hovering_object->m_obj);
             return 1;
@@ -856,14 +856,14 @@ bool cEditor::Mouse_Down(Uint8 button)
     return 1;
 }
 
-bool cEditor::Mouse_Up(Uint8 button)
+bool cEditor::Mouse_Up(sf::Mouse::Button button)
 {
     if (!m_enabled) {
         return 0;
     }
 
     // left
-    if (button == SDL_BUTTON_LEFT) {
+    if (button == sf::Mouse::Left) {
         // unhide
         if (pPreferences->m_editor_mouse_auto_hide) {
             pMouseCursor->Set_Active(1);
@@ -884,7 +884,7 @@ bool cEditor::Mouse_Up(Uint8 button)
         }
     }
     // middle
-    else if (button == SDL_BUTTON_MIDDLE) {
+    else if (button == sf::Mouse::Middle) {
         pMouseCursor->m_fastcopy_mode = 0;
     }
     else {

--- a/tsc/src/core/editor/editor.hpp
+++ b/tsc/src/core/editor/editor.hpp
@@ -136,11 +136,11 @@ namespace TSC {
         /* handle mouse button down event
          * returns true if processed
         */
-        virtual bool Mouse_Down(Uint8 button);
+        virtual bool Mouse_Down(sf::Mouse::Button button);
         /* handle mouse button up event
          * returns true if processed
         */
-        virtual bool Mouse_Up(Uint8 button);
+        virtual bool Mouse_Up(sf::Mouse::Button button);
 
         // Set the parent sprite manager
         virtual void Set_Sprite_Manager(cSprite_Manager* sprite_manager);

--- a/tsc/src/gui/menu.cpp
+++ b/tsc/src/gui/menu.cpp
@@ -440,10 +440,10 @@ bool cMenuCore::Joy_Button_Up(unsigned int button)
     return 1;
 }
 
-bool cMenuCore::Mouse_Down(Uint8 button)
+bool cMenuCore::Mouse_Down(sf::Mouse::Button button)
 {
     // nothing yet
-    if (button == SDL_BUTTON_LEFT) {
+    if (button == sf::Mouse::Left) {
         cMenu_Item* item = m_handler->Get_Active_Item();
 
         if (item && item->m_col_rect.Intersects(static_cast<float>(pMouseCursor->m_x), static_cast<float>(pMouseCursor->m_y))) {
@@ -460,19 +460,10 @@ bool cMenuCore::Mouse_Down(Uint8 button)
     return 1;
 }
 
-bool cMenuCore::Mouse_Up(Uint8 button)
+bool cMenuCore::Mouse_Up(sf::Mouse::Button button)
 {
-    // nothing yet
-    if (0) {
-        //
-    }
-    else {
-        // not processed
-        return 0;
-    }
-
-    // button got processed
-    return 1;
+    // not processed
+    return 0;
 }
 
 cMenu_Item* cMenuCore::Auto_Menu(std::string imagename, std::string imagefilename_menu, float ypos /* = 0 */, bool is_quit /* = 0 */)

--- a/tsc/src/gui/menu.hpp
+++ b/tsc/src/gui/menu.hpp
@@ -125,11 +125,11 @@ namespace TSC {
         /* handle mouse button down event
          * returns true if processed
         */
-        bool Mouse_Down(Uint8 button);
+        bool Mouse_Down(sf::Mouse::Button button);
         /* handle mouse button up event
          * returns true if processed
         */
-        bool Mouse_Up(Uint8 button);
+        bool Mouse_Up(sf::Mouse::Button button);
         /* handle joystick button down event
          * returns true if processed
         */

--- a/tsc/src/input/mouse.cpp
+++ b/tsc/src/input/mouse.cpp
@@ -1414,6 +1414,9 @@ void cMouseCursor::Toggle_Mover_Mode(void)
 {
     m_mover_mode = !m_mover_mode;
 
+    m_mover_center_x = m_x * global_upscalex;
+    m_mover_center_y = m_y * global_upscaley;
+
     if (m_mover_mode) {
         CEGUI::MouseCursor::getSingleton().setImage("TaharezLook", "MouseMoveCursor");
     }
@@ -1422,16 +1425,16 @@ void cMouseCursor::Toggle_Mover_Mode(void)
     }
 }
 
-void cMouseCursor::Mover_Update(Sint16 move_x, Sint16 move_y)
+void cMouseCursor::Mover_Update(int move_x, int move_y)
 {
     if (!m_mover_mode) {
         return;
     }
 
     // mouse moves the camera
-    pActive_Camera->Move(move_x, move_y);
+    pActive_Camera->Move(move_x - m_mover_center_x, move_y - m_mover_center_y);
     // keep mouse at it's position
-    sf::Mouse::setPosition(sf::Vector2i(m_x * global_upscalex, m_y * global_upscaley));
+    sf::Mouse::setPosition(sf::Vector2i(m_mover_center_x, m_mover_center_y));
 
     sf::Event inEvent;
 

--- a/tsc/src/input/mouse.hpp
+++ b/tsc/src/input/mouse.hpp
@@ -220,7 +220,7 @@ namespace TSC {
         // Toggle Mover mode
         void Toggle_Mover_Mode(void);
         // Updates the Mover Mode
-        void Mover_Update(Sint16 move_x, Sint16 move_y);
+        void Mover_Update(int move_x, int move_y);
         // Updates the editor Mouse
         void Editor_Update(void);
 
@@ -235,6 +235,9 @@ namespace TSC {
 
         // if activated the mouse cursor movement moves the screen
         bool m_mover_mode;
+        // The position of the cursor when it entered mover mode
+        int m_mover_center_x;
+        int m_mover_center_y;
         // fast copy mode
         bool m_fastcopy_mode;
 

--- a/tsc/src/level/level.cpp
+++ b/tsc/src/level/level.cpp
@@ -844,7 +844,7 @@ bool cLevel::Key_Up(const sf::Event& evt)
     return 1;
 }
 
-bool cLevel::Mouse_Down(Uint8 button)
+bool cLevel::Mouse_Down(sf::Mouse::Button button)
 {
     // ## editor
     if (pLevel_Editor->Mouse_Down(button)) {
@@ -860,7 +860,7 @@ bool cLevel::Mouse_Down(Uint8 button)
     return 1;
 }
 
-bool cLevel::Mouse_Up(Uint8 button)
+bool cLevel::Mouse_Up(sf::Mouse::Button button)
 {
     // ## editor
     if (pLevel_Editor->Mouse_Up(button)) {

--- a/tsc/src/level/level.hpp
+++ b/tsc/src/level/level.hpp
@@ -101,11 +101,11 @@ namespace TSC {
         /* handle mouse button down event
          * returns true if processed
         */
-        bool Mouse_Down(Uint8 button);
+        bool Mouse_Down(sf::Mouse::Button button);
         /* handle mouse button up event
          * returns true if processed
         */
-        bool Mouse_Up(Uint8 button);
+        bool Mouse_Up(sf::Mouse::Button button);
         /* handle joystick button down event
          * returns true if processed
         */

--- a/tsc/src/overworld/overworld.cpp
+++ b/tsc/src/overworld/overworld.cpp
@@ -617,7 +617,7 @@ bool cOverworld::Key_Up(const sf::Event& evt)
     return 1;
 }
 
-bool cOverworld::Mouse_Down(Uint8 button)
+bool cOverworld::Mouse_Down(sf::Mouse::Button button)
 {
     // ## editor
     if (pWorld_Editor->Mouse_Down(button)) {
@@ -633,7 +633,7 @@ bool cOverworld::Mouse_Down(Uint8 button)
     return 1;
 }
 
-bool cOverworld::Mouse_Up(Uint8 button)
+bool cOverworld::Mouse_Up(sf::Mouse::Button button)
 {
     // ## editor
     if (pWorld_Editor->Mouse_Up(button)) {

--- a/tsc/src/overworld/overworld.hpp
+++ b/tsc/src/overworld/overworld.hpp
@@ -125,11 +125,11 @@ namespace TSC {
         /* handle mouse button down event
          * returns true if processed
         */
-        bool Mouse_Down(Uint8 button);
+        bool Mouse_Down(sf::Mouse::Button button);
         /* handle mouse button up event
          * returns true if processed
         */
-        bool Mouse_Up(Uint8 button);
+        bool Mouse_Up(sf::Mouse::Button button);
         /* handle joystick button down event
          * returns true if processed
         */


### PR DESCRIPTION
Ported the editor's mover mode to SFML.  The only issue is that the mouse shudders when moving. This because SFML doesn't any facility to lock the mouse, and the mouse has to instead be moved back to its starting position.