### PR TITLE
Fix CEGUI input in SFML port

### DIFF
--- a/tsc/src/core/main.cpp
+++ b/tsc/src/core/main.cpp
@@ -503,6 +503,12 @@ bool Handle_Input_Global(const sf::Event& ev)
         pGuiSystem->notifyDisplaySizeChanged(CEGUI::Size(static_cast<float>(ev.size.width), static_cast<float>(ev.size.height)));
         break;
     }
+    case sf::Event::TextEntered: {
+        if (pKeyboard->Text_Entered(ev)) {
+            return 1;
+        }
+        break;
+    }
     case sf::Event::KeyPressed: {
         if (pKeyboard->Key_Down(ev)) {
             return 1;

--- a/tsc/src/gui/generic.cpp
+++ b/tsc/src/gui/generic.cpp
@@ -120,7 +120,10 @@ std::string cDialogBox_Text::Enter(std::string default_text, std::string title_t
 
     while (!finished) {
         while (pVideo->mp_window->pollEvent(input_event)) {
-            if (input_event.type == sf::Event::KeyPressed) {
+            if (input_event.type == sf::Event::TextEntered) {
+                pKeyboard->Text_Entered(input_event);
+            }
+            else if (input_event.type == sf::Event::KeyPressed) {
                 if (auto_no_text && default_text.compare(box_editbox->getText().c_str()) == 0) {
                     box_editbox->setText("");
                     // only the first time
@@ -237,7 +240,10 @@ int cDialogBox_Question::Enter(std::string text, bool with_cancel /* = 0 */)
         Draw();
 
         while (pVideo->mp_window->pollEvent(input_event)) {
-            if (input_event.type == sf::Event::KeyPressed) {
+            if (input_event.type == sf::Event::TextEntered) {
+                pKeyboard->Text_Entered(input_event);
+            }
+            else if (input_event.type == sf::Event::KeyPressed) {
                 if (input_event.key.code == sf::Keyboard::Escape) {
                     if (with_cancel) {
                         return_value = -1;

--- a/tsc/src/input/keyboard.cpp
+++ b/tsc/src/input/keyboard.cpp
@@ -86,18 +86,6 @@ bool cKeyboard::CEGUI_Handle_Key_Down(sf::Keyboard::Key key) const
         return 1;
     }
 
-    // TODO: The following should rather be replaced with the sf::TextEntered
-    // event. However, I’m not sure if typing on the keyboard generates both
-    // sf::KeyPressed/sf::Keyreleased and sf::TextEntered events...
-
-    // OLD // use for translated unicode value
-    // OLD if (input_event.key.keysym.unicode != 0) {
-    // OLD     if (pGuiSystem->injectChar(input_event.key.keysym.unicode)) {
-    // OLD         // input got processed by the gui system
-    // OLD         return 1;
-    // OLD     }
-    // OLD }
-
     return 0;
 }
 
@@ -250,6 +238,22 @@ bool cKeyboard::Key_Down(const sf::Event& evt)
     }
 
     return 0;
+}
+
+bool cKeyboard::CEGUI_Handle_Text_Entered(Uint32 character)
+{
+    if (pGuiSystem->injectChar(character)) {
+        // input got processed by the gui system
+        return 1;
+    }
+}
+
+bool cKeyboard::Text_Entered(const sf::Event& evt)
+{
+    if (CEGUI_Handle_Text_Entered(evt.text.unicode)) {
+        // input got processed by the gui system
+        return 1;
+    }
 }
 
 unsigned int cKeyboard::SFMLKey_to_CEGUIKey(const sf::Keyboard::Key key) const

--- a/tsc/src/input/keyboard.hpp
+++ b/tsc/src/input/keyboard.hpp
@@ -63,6 +63,16 @@ namespace TSC {
         */
         bool Key_Down(const sf::Event& evt);
 
+        /* CEGUI Text Entry handler
+         * returns true if CEGUI processed the given text entry event
+        */
+        bool CEGUI_Handle_Text_Entered(Uint32 character);
+
+        /* Text Entry handler
+         * returns true if the event was processed
+        */
+        bool Text_Entered(const sf::Event& evt);
+
         // Translate a SFMLKey to the proper CEGUI::Key
         unsigned int SFMLKey_to_CEGUIKey(const sf::Keyboard::Key key) const;
     };


### PR DESCRIPTION
Created a new handler for text entry in cKeyboard. This should allow text to be entered into CEGUI components. Any new class that uses text entry should be added in cKeyboard::Text_Entry.