### PR TITLE
Fixed Font to use UTF-8 encodings instead of plain ASCII.

### DIFF
--- a/tsc/src/video/font.cpp
+++ b/tsc/src/video/font.cpp
@@ -73,9 +73,8 @@ void cFont_Manager::Queue_Text(const sf::Text& text)
  */
 void cFont_Manager::Prepare_SFML_Text(sf::Text& text, const std::string& str, float x, float y, int fontsize /* = FONTSIZE_NORMAL */, const Color color /* = black */, bool ignore_camera /* = false */)
 {
-    std::basic_string<sf::Uint32> tmp;
-    sf::Utf8::toUtf32(str.begin(), str.end(), std::back_inserter(tmp));
-    sf::String utf8Str = tmp;
+    wstring utf8Str;
+    sf::Utf8::toUtf32(str.begin(), str.end(), std::back_inserter(utf8Str));
 
     text.setFont(m_font_normal);
     text.setColor(color.Get_SFML_Color());

--- a/tsc/src/video/font.cpp
+++ b/tsc/src/video/font.cpp
@@ -73,11 +73,14 @@ void cFont_Manager::Queue_Text(const sf::Text& text)
  */
 void cFont_Manager::Prepare_SFML_Text(sf::Text& text, const std::string& str, float x, float y, int fontsize /* = FONTSIZE_NORMAL */, const Color color /* = black */, bool ignore_camera /* = false */)
 {
+    std::basic_string<sf::Uint32> tmp;
+    sf::Utf8::toUtf32(str.begin(), str.end(), std::back_inserter(tmp));
+    sf::String utf8Str = tmp;
 
     text.setFont(m_font_normal);
     text.setColor(color.Get_SFML_Color());
     text.setCharacterSize(fontsize);
-    text.setString(str);
+    text.setString(utf8Str);
 
     if (ignore_camera) {
         // SFML thinks 0|0 is left top of the window

--- a/tsc/src/video/font.cpp
+++ b/tsc/src/video/font.cpp
@@ -73,13 +73,13 @@ void cFont_Manager::Queue_Text(const sf::Text& text)
  */
 void cFont_Manager::Prepare_SFML_Text(sf::Text& text, const std::string& str, float x, float y, int fontsize /* = FONTSIZE_NORMAL */, const Color color /* = black */, bool ignore_camera /* = false */)
 {
-    wstring utf8Str;
-    sf::Utf8::toUtf32(str.begin(), str.end(), std::back_inserter(utf8Str));
+    wstring utf32Str;
+    sf::Utf8::toUtf32(str.begin(), str.end(), std::back_inserter(utf32Str));
 
     text.setFont(m_font_normal);
     text.setColor(color.Get_SFML_Color());
     text.setCharacterSize(fontsize);
-    text.setString(utf8Str);
+    text.setString(utf32Str);
 
     if (ignore_camera) {
         // SFML thinks 0|0 is left top of the window


### PR DESCRIPTION
Changed the Font class to use a UTF encoding rather than straight ASCII. This should fix #528.

@xet7 @Quintus The box characters should be replaced with the correct characters. You should test this on Finnish and German locales.