### PR TITLE
Fix wrong song played after invincibility is over

### DIFF
--- a/tsc/src/audio/audio.cpp
+++ b/tsc/src/audio/audio.cpp
@@ -644,7 +644,7 @@ void cAudio::Update(void)
     // if music is enabled but nothing is playing
     if (m_music_enabled && !Is_Music_Playing() && !m_next_music.empty()) {
         // play the next song in the queue
-        NextMusicInfo next = m_next_music.front();
+        NextMusicInfo next = m_next_music.top();
         m_next_music.pop();
         Play_Music(next.filename, next.loops, true, next.fadein_ms);
     }

--- a/tsc/src/audio/audio.hpp
+++ b/tsc/src/audio/audio.hpp
@@ -199,7 +199,7 @@ namespace TSC {
         // current playing music pointer
         sf::Music m_music;
         // next music to play
-        std::queue<NextMusicInfo> m_next_music;
+        std::stack<NextMusicInfo> m_next_music;
 
         // The current sounds pointer array
         AudioSoundList m_active_sounds;


### PR DESCRIPTION
Fixes #580.

This is due to the wrong data structure choice. A queue is an FIFO data structure, so this happened:

- The title screen music was queued when the level was opened.

- The level music was queued when the invincibility music stasrted playing

- When the invincibility music stopped playing, the title screen music was pulled off the queue and started playing.

Now, a stack is being used, which is LIFO, so in the above example, the level music will be pulled off instead of the title screen music.

(FWIW I haven't gotten to actually test this, but off the top of my head, this should do the track.)