### PR TITLE
Fading sounds/music no longer hang the game

### DIFF
--- a/tsc/src/audio/audio.cpp
+++ b/tsc/src/audio/audio.cpp
@@ -124,18 +124,11 @@ cAudio::~cAudio(void)
 
 bool cAudio::Init(void)
 {
-    // Get current device parameters
-    int dev_frequency = 0;
-    uint16_t dev_format = 0;
-    int dev_channels = 0;
-    /* int numtimesopened = Mix_QuerySpec(&dev_frequency, &dev_format, &dev_channels); XXX: SFML doesn't seem to have the ability to set audio frequencies... */
-    int numtimesopened = 0;
-
     bool sound = pPreferences->m_audio_sound;
     bool music = pPreferences->m_audio_music;
 
     // if no change
-    if (numtimesopened && m_music_enabled == music && m_sound_enabled == sound && dev_frequency == pPreferences->m_audio_hz) {
+    if (m_music_enabled == music && m_sound_enabled == sound) {
         return 1;
     }
 
@@ -206,6 +199,8 @@ void cAudio::Close(bool close_sound/*=true*/, bool close_music/*=true*/)
 
         m_initialised = 0;
     }
+
+    m_fade_direction = FadeDirection::NONE;
 }
 
 cSound* cAudio::Get_Sound_File(fs::path filename) const
@@ -342,24 +337,14 @@ bool cAudio::Play_Music(fs::path filename, bool loops /* = false */, bool force 
         }
 
         m_music.setLoop(loops);
-        // no fade in
-        if (!fadein_ms) {
-            m_music.play();
+        // set up fade in
+        if (fadein_ms) {
+            m_music.setVolume(0);
+            m_fade_direction = FadeDirection::IN;
+            m_fade_time_start = std::chrono::high_resolution_clock::now();
+            m_fade_time_total = fadein_ms;
         }
-        // fade in
-        else {
-            float current = m_music.getVolume();
-            float count = fadein_ms / m_music.getVolume();
-            m_music.setVolume(count);
-            m_music.play();
-            while (m_music.getVolume() < current) {
-                // sleep for several milliseconds
-                boost::this_thread::sleep_for(boost::chrono::milliseconds(int(fadein_ms / count)));
-                // raise the volume
-                m_music.setVolume(int(m_music.getVolume()+count));
-            }
-            m_music.setVolume(current);
-        }
+        m_music.play();
     }
     // music is playing and is not forced
     else {
@@ -472,64 +457,6 @@ void cAudio::Resume_Music(void)
     }
 }
 
-void cAudio::Fadeout_Source(sf::SoundSource& source, unsigned int ms) {
-    // count is the amount to decrease the sound by
-    float count = ms / source.getVolume();
-    while (source.getVolume() > count) {
-        // sleep for several milliseconds
-        boost::this_thread::sleep_for(boost::chrono::milliseconds(int(ms / count)));
-        // lower the volume
-        source.setVolume(int(source.getVolume()-count));
-    }
-    source.setVolume(0);
-}
-
-void cAudio::Fadeout_Sounds(unsigned int ms /* = 200 */)
-{
-    if (!m_sound_enabled || !m_initialised) {
-        return;
-    }
-
-    // if not playing
-    if (!Is_Music_Playing()) {
-        return;
-    }
-
-    // get all sounds
-    for (AudioSoundList::iterator itr = m_active_sounds.begin(); itr != m_active_sounds.end(); ++itr) {
-        // get object pointer
-        cAudio_Sound* obj = (*itr);
-
-        // fade the sound
-        Fadeout_Source(obj->m_sound, ms);
-    }
-}
-
-void cAudio::Fadeout_Sounds(unsigned int ms, fs::path filename)
-{
-    if (!m_sound_enabled || !m_initialised) {
-        return;
-    }
-
-    // add sound directory
-    if (!filename.is_absolute())
-        filename = pPackage_Manager->Get_Sound_Reading_Path(path_to_utf8(filename));
-
-    // get all sounds
-    for (AudioSoundList::iterator itr = m_active_sounds.begin(); itr != m_active_sounds.end(); ++itr) {
-        // get object pointer
-        cAudio_Sound* obj = (*itr);
-
-        // filename does not match
-        if (obj->m_data->m_filename.compare(filename) != 0) {
-            continue;
-        }
-
-        // fade the sound
-        Fadeout_Source(obj->m_sound, ms);
-    }
-}
-
 void cAudio::Fadeout_Music(unsigned int ms /* = 500 */)
 {
     if (!m_music_enabled || !m_initialised) {
@@ -541,11 +468,9 @@ void cAudio::Fadeout_Music(unsigned int ms /* = 500 */)
         return;
     }
 
-    float orig = m_music.getVolume();
-    Fadeout_Source(m_music, ms);
-    Halt_Music();
-    // reset volume after the sound stops
-    m_music.setVolume(orig);
+    m_fade_direction = FadeDirection::OUT;
+    m_fade_time_start = std::chrono::high_resolution_clock::now();
+    m_fade_time_total = ms;
 }
 
 void cAudio::Set_Music_Position(float position)
@@ -582,6 +507,7 @@ void cAudio::Halt_Music(void)
     }
 
     m_music.stop();
+    m_fade_direction = FadeDirection::NONE;
 }
 
 void cAudio::Stop_Sounds(void) const
@@ -632,21 +558,44 @@ void cAudio::Set_Music_Volume(uint8_t volume)
         volume = MAX_VOLUME;
     }
 
-    m_music.setVolume(volume);
+    m_music_volume = volume;
 }
 
 void cAudio::Update(void)
 {
-    if (!m_initialised) {
+    if (!m_initialised || !m_music_enabled) {
         return;
     }
 
     // if music is enabled but nothing is playing
-    if (m_music_enabled && !Is_Music_Playing() && !m_next_music.empty()) {
+    if (!Is_Music_Playing() && !m_next_music.empty()) {
         // play the next song in the queue
         NextMusicInfo next = m_next_music.top();
         m_next_music.pop();
         Play_Music(next.filename, next.loops, true, next.fadein_ms);
+    }
+    // if we are currently fading music
+    else if (m_fade_direction != FadeDirection::NONE) {
+        auto passed = std::chrono::high_resolution_clock::now() - m_fade_time_start;
+        unsigned int passed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(passed).count();
+        if (passed_ms >= m_fade_time_total) {
+            // done fading; reset volume
+            if (m_fade_direction == FadeDirection::OUT) {
+                Halt_Music();
+            }
+            m_music.setVolume(m_music_volume);
+            m_fade_direction = FadeDirection::NONE;
+        } else {
+            // update volume
+            float new_volume = m_music_volume * (static_cast<float>(passed_ms) / m_fade_time_total);
+            if (m_fade_direction == FadeDirection::OUT) {
+                new_volume = MAX_VOLUME - new_volume;
+            }
+            m_music.setVolume(new_volume);
+        }
+    } else {
+        // make sure current volume is up-to-date
+        m_music.setVolume(m_music_volume);
     }
 }
 

--- a/tsc/src/audio/audio.hpp
+++ b/tsc/src/audio/audio.hpp
@@ -143,18 +143,6 @@ namespace TSC {
         // Resume Music
         void Resume_Music(void);
 
-        // Fade out the sound source
-        void Fadeout_Source(sf::SoundSource& source, unsigned int ms);
-        /* Fade out Sound(s)
-         * ms : the time to fade out
-         * overwrite_fading : overwrite an already existing fade out
-        */
-        void Fadeout_Sounds(unsigned int ms = 200);
-        /* Fade out Sound(s)
-         * ms : the time to fade out
-         * filename : fade all sounds with this filename out
-        */
-        void Fadeout_Sounds(unsigned int ms, boost::filesystem::path filename);
         /* Fade out Music
          * ms : the time to fade out
         */
@@ -196,8 +184,16 @@ namespace TSC {
 
         // current playing music filename
         boost::filesystem::path m_music_filename;
-        // current playing music pointer
+        // current playing music
         sf::Music m_music;
+
+        enum class FadeDirection { NONE, IN, OUT };
+        FadeDirection m_fade_direction;
+        // fading time start
+        std::chrono::time_point<std::chrono::high_resolution_clock> m_fade_time_start;
+        // fading time total
+        unsigned int m_fade_time_total;
+
         // next music to play
         std::stack<NextMusicInfo> m_next_music;
 
@@ -206,9 +202,6 @@ namespace TSC {
 
         // maximum sounds allowed at once
         unsigned int m_max_sounds;
-
-        // initialization information
-        /* int m_audio_buffer, m_audio_channels; */
     };
 
     /* *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** */

--- a/tsc/src/audio/random_sound.cpp
+++ b/tsc/src/audio/random_sound.cpp
@@ -411,7 +411,6 @@ bool cRandom_Sound::Is_Update_Valid()
 
     // if outside the range
     if (m_distance_to_camera >= m_volume_reduction_end) {
-        Event_Out_Of_Range();
         return 0;
     }
 
@@ -431,12 +430,6 @@ bool cRandom_Sound::Is_Draw_Valid(void)
     }
 
     return 1;
-}
-
-void cRandom_Sound::Event_Out_Of_Range(void) const
-{
-    // fade out sounds if out of range
-    pAudio->Fadeout_Sounds(500, m_filename);
 }
 
 #ifdef ENABLE_EDITOR

--- a/tsc/src/audio/random_sound.hpp
+++ b/tsc/src/audio/random_sound.hpp
@@ -85,9 +85,6 @@ namespace TSC {
         // if draw is valid for the current state and position
         virtual bool Is_Draw_Valid(void);
 
-        // if camera went out of range
-        void Event_Out_Of_Range(void) const;
-
 #ifdef ENABLE_EDITOR
         // editor activation
         virtual void Editor_Activate(void);


### PR DESCRIPTION
Fixes #549.

Previously, fading sounds/music (accidentally) would hang the entire game loop. Obviously, this is very bad.

Now, the fade state is saved within the cAudio engine. When a fade for music is initiated,
the start time, duration, and fade direction are saved, and then the volume is updated at
each iteration of the main loop.

Fading for sounds has been removed, because it would have been harder to implement and no one
could hear the difference anyway...