### PR TITLE
Add Flatpak support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ CMakeLists.txt.user*
 # Gedit and Emacs
 *~
 
+# Flatpak
+/.flatpak-builder
+
 # Installer
 /tsc/extras/Setup/*.exe
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,9 @@
 [submodule "tinyclipboard"]
 	path = tinyclipboard
 	url = git://git.guelkerdev.de/tinyclipboard.git
+[submodule "shared-modules"]
+	path = flatpak/shared-modules
+	url = https://github.com/flathub/shared-modules
+[submodule "flatpak/shared-modules"]
+	path = flatpak/shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/org.secretchronicles.TSC.json
+++ b/org.secretchronicles.TSC.json
@@ -1,0 +1,238 @@
+{
+    "app-id": "org.secretchronicles.TSC",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "18.08",
+    "sdk": "org.freedesktop.Sdk",
+    "command": "tsc",
+    "rename-icon": "tsc",
+    "rename-appdata-file": "tsc.appdata.xml",
+    "rename-desktop-file": "tsc.desktop",
+    "desktop-file-name-prefix": "(Nightly) ",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=pulseaudio",
+        "--socket=x11",
+        "--socket=wayland"
+    ],
+    "cleanup": [
+        "/bin/mm-common-prepare",
+        "/bin/mrbc",
+        "/include/",
+        "/lib/cmake/",
+        "/lib/giomm-2.4/",
+        "/lib/glibmm-2.4/",
+        "/lib/pkgconfig/",
+        "/lib/sigc++-2.0/",
+        "/lib64/cmake/",
+        "/lib64/pkgconfig/",
+        "/share/aclocal/",
+        "/share/doc/",
+        "/share/man/",
+        "/share/mm-common/",
+        "/share/pkgconfig/",
+        "/share/SFML/",
+        "*.a"
+    ],
+    "modules": [
+        {
+            "name": "boost",
+            "buildsystem": "simple",
+            "build-commands": [
+                "./bootstrap.sh --prefix=/app",
+                "./b2 install --with-atomic --with-chrono --with-date_time --with-filesystem --with-thread"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2",
+                    "sha256": "7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7"
+                }
+            ]
+        },
+        {
+            "name": "glm",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/g-truc/glm/archive/0.9.9.0.tar.gz",
+                    "sha256": "514dea9ac0099dc389cf293cf1ab3d97aff080abad55bf79d4ab7ff6895ee69c"
+                }
+            ]
+        },
+        "flatpak/shared-modules/glew/glew.json",
+        "flatpak/shared-modules/glu/glu-9.0.0.json",
+        "flatpak/shared-modules/udev/udev-175.json",
+        {
+            "name": "devil",
+            "buildsystem": "cmake-ninja",
+            "subdir": "DevIL",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://downloads.sourceforge.net/openil/DevIL-1.8.0.tar.gz",
+                    "sha256": "0075973ee7dd89f0507873e2580ac78336452d29d34a07134b208f44e2feb709"
+                }
+            ]
+        },
+        {
+            "name": "cegui",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://bitbucket.org/cegui/cegui/downloads/cegui-0.8.7.tar.bz2",
+                    "sha256": "b351e8957716d9c170612c13559e49530ef911ae4bac2feeb2dacd70b430e518"
+                }
+            ]
+        },
+        {
+            "name": "sfml",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/SFML/SFML/archive/2.5.0.tar.gz",
+                    "sha256": "4bc5ed0b6658f73a31bfb8b36878d71fe1678e6e95e4f20834ab589a1bdc7ef4"
+                }
+            ]
+        },
+        {
+            "name": "mm-common",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/mm-common/0.9/mm-common-0.9.12.tar.xz",
+                    "sha256": "ceffdcce1e5b52742884c233ec604bf6fded12eea9da077ce7a62c02c87e7c0b"
+                }
+            ]
+        },
+        {
+            "name": "libsigcpp",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.0.tar.xz",
+                    "sha256": "f843d6346260bfcb4426259e314512b99e296e8ca241d771d21ac64f28298d81"
+                }
+            ]
+        },
+        {
+            "name": "glibmm",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.56/glibmm-2.56.0.tar.xz",
+                    "sha256": "6e74fcba0d245451c58fc8a196e9d103789bc510e1eee1a9b1e816c5209e79a9"
+                }
+            ]
+        },
+        {
+            "name": "libxmlpp",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/libxml++/2.40/libxml++-2.40.1.tar.xz",
+                    "sha256": "4ad4abdd3258874f61c2e2a41d08e9930677976d303653cd1670d3e9f35463e9"
+                }
+            ]
+        },
+        {
+            "name": "tinyclipboard",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make install PREFIX=/app"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://files.guelker.eu/projects/tinyclipboard/tinyclipboard-16.01.tar.gz",
+                    "sha256": "a5d16f09792183963f7c35e7e27ef9a7bb476bfee230f9bc0bd65df02f5d8429"
+                }
+            ]
+        },
+        {
+            "name": "mruby",
+            "buildsystem": "simple",
+            "build-commands": [
+                "sed -i s+#{THIS_DIR}/../mruby/mgems/++g build_config.rb",
+                "./minirake",
+                "cp -rv include/* /app/include",
+                "cp -rv build/host/lib/* /app/lib"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/mruby/mruby/archive/1.4.1.tar.gz",
+                    "sha256": "2469b1f3e3c97a34f8c3dca1bca9795f66d6b17c7be60ddfc1f3b502cdcbb400"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/mattn/mruby-json",
+                    "commit": "0a32553d255e62e63ffaa70b12e53767c7da7240",
+                    "dest": "mruby-json"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/mattn/mruby-md5",
+                    "commit": "8383c078248c4a562e99ee96e3979d7034b47fc6",
+                    "dest": "mruby-md5"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/mattn/mruby-pcre-regexp",
+                    "commit": "69344b357a94e258c94addc2a74402d6de5c509d",
+                    "dest": "mruby-pcre-regexp"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/matsumotory/mruby-sleep",
+                    "commit": "7a2a6a35cae42894e2ac1ef93548af83fec9b275",
+                    "dest": "mruby-sleep"
+                },
+                {
+                    "type": "file",
+                    "path": "tsc/mruby_tsc_build_config.rb",
+                    "dest-filename": "build_config.rb"
+                }
+            ]
+        },
+        {
+            "name": "tsc",
+            "buildsystem": "cmake",
+            "subdir": "tsc",
+            "config-opts": [
+                "-DUSE_SYSTEM_MRUBY=ON",
+                "-DUSE_SYSTEM_TINYCLIPBOARD=ON",
+                "-DCMAKE_BUILD_TYPE=Debug"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "path": "https://github.com/Secretchronicles/TSC"
+                },
+                {
+                    "type": "file",
+                    "path": "COPYING",
+                    "dest-filename": "tsc/COPYING"
+                }
+            ]
+        }
+    ]
+}

--- a/tsc/CMakeLists.txt
+++ b/tsc/CMakeLists.txt
@@ -49,6 +49,7 @@ option(ENABLE_MRUBY "Enable the MRuby scripting engine" ON)
 option(ENABLE_NLS "Enable translations and localisations" ON)
 option(ENABLE_EDITOR "Enable the in-game editor" ON)
 option(USE_SYSTEM_TINYCLIPBOARD "Use the system's tinyclipboard library" OFF)
+option(USE_SYSTEM_MRUBY "Use the system's mruby (intended for internal use only!)" OFF)
 option(USE_LIBXMLPP3 "Use libxml++3.0 instead of libxml++2.6 (experimental)" OFF)
 
 ########################################
@@ -245,7 +246,7 @@ else()
   endif()
 endif()
 
-if (ENABLE_MRUBY)
+if (ENABLE_MRUBY AND NOT USE_SYSTEM_MRUBY)
   add_dependencies(tsc mruby)
 endif()
 
@@ -315,6 +316,9 @@ install(FILES "${TSC_SOURCE_DIR}/extras/icons/tsc_icon_128.png"
   COMPONENT base)
 install(FILES "${TSC_SOURCE_DIR}/extras/tsc.desktop"
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications
+  COMPONENT base)
+install(FILES "${TSC_SOURCE_DIR}/extras/tsc.appdata.xml"
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/appdata
   COMPONENT base)
 
 foreach(pofile ${po_files})
@@ -403,6 +407,7 @@ message(STATUS "Enable the in-game editor:         ${ENABLE_EDITOR}")
 message(STATUS "Enable the mruby scripting engine: ${ENABLE_MRUBY}")
 message(STATUS "Enable native language support:    ${ENABLE_NLS}")
 message(STATUS "Use system-provided tinyclipboard: ${USE_SYSTEM_TINYCLIPBOARD}")
+message(STATUS "Use system-provided mruby:         ${USE_SYSTEM_MRUBY}")
 
 message(STATUS "--------------- Path configuration -----------------")
 message(STATUS "Install prefix:        ${CMAKE_INSTALL_PREFIX}")

--- a/tsc/cmake/modules/ProvideMRuby.cmake
+++ b/tsc/cmake/modules/ProvideMRuby.cmake
@@ -1,27 +1,34 @@
-message("-- Scripting engine enabled: building mruby statically")
+if (USE_SYSTEM_MRUBY)
+  find_path(MRuby_INCLUDE_DIR mruby.h)
+  find_library(MRuby_LIBRARIES mruby mruby_core)
 
-# mruby requires Bison and ruby to compile. Ruby is checked
-# for on the toplevel anyway.
-find_package(BISON REQUIRED)
-
-if(CMAKE_CROSSCOMPILING)
-  # Appearently no libmruby_core.a library when crosscompiling?
-  set(MRuby_LIBRARIES "${TSC_BINARY_DIR}/mruby/build/${HOST_TRIPLET}/lib/libmruby.a")
+  message("-- Scripting engine enabled; found mruby at ${MRuby_LIBRARIES}")
 else()
-  set(MRuby_LIBRARIES "${TSC_BINARY_DIR}/mruby/build/host/lib/libmruby.a" "${TSC_BINARY_DIR}/mruby/build/host/lib/libmruby_core.a")
+  message("-- Scripting engine enabled: building mruby statically")
+
+  # mruby requires Bison and ruby to compile. Ruby is checked
+  # for on the toplevel anyway.
+  find_package(BISON REQUIRED)
+
+  if(CMAKE_CROSSCOMPILING)
+    # Appearently no libmruby_core.a library when crosscompiling?
+    set(MRuby_LIBRARIES "${TSC_BINARY_DIR}/mruby/build/${HOST_TRIPLET}/lib/libmruby.a")
+  else()
+    set(MRuby_LIBRARIES "${TSC_BINARY_DIR}/mruby/build/host/lib/libmruby.a" "${TSC_BINARY_DIR}/mruby/build/host/lib/libmruby_core.a")
+  endif()
+
+  # The CROSSCOMPILE_TARGET environment variable is used by our custom
+  # mruby_tsc_build_config.rb build script for mruby. It is not part
+  # of mruby's official build documentation.
+  ExternalProject_Add(
+    mruby
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory "${TSC_SOURCE_DIR}/../mruby/mruby" "${TSC_BINARY_DIR}/mruby"
+    SOURCE_DIR "${TSC_BINARY_DIR}/mruby"
+    CONFIGURE_COMMAND ""
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND ./minirake MRUBY_CONFIG=${TSC_SOURCE_DIR}/mruby_tsc_build_config.rb CROSSCOMPILE_TARGET=${HOST_TRIPLET}
+    BUILD_BYPRODUCTS ${MRuby_LIBRARIES}
+    INSTALL_COMMAND "")
+
+  set(MRuby_INCLUDE_DIR ${TSC_SOURCE_DIR}/../mruby/mruby/include)
 endif()
-
-# The CROSSCOMPILE_TARGET environment variable is used by our custom
-# mruby_tsc_build_config.rb build script for mruby. It is not part
-# of mruby's official build documentation.
-ExternalProject_Add(
-  mruby
-  DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory "${TSC_SOURCE_DIR}/../mruby/mruby" "${TSC_BINARY_DIR}/mruby"
-  SOURCE_DIR "${TSC_BINARY_DIR}/mruby"
-  CONFIGURE_COMMAND ""
-  BUILD_IN_SOURCE 1
-  BUILD_COMMAND ./minirake MRUBY_CONFIG=${TSC_SOURCE_DIR}/mruby_tsc_build_config.rb CROSSCOMPILE_TARGET=${HOST_TRIPLET}
-  BUILD_BYPRODUCTS ${MRuby_LIBRARIES}
-  INSTALL_COMMAND "")
-
-set(MRuby_INCLUDE_DIR ${TSC_SOURCE_DIR}/../mruby/mruby/include)

--- a/tsc/cmake/modules/ProvideTinyclipboard.cmake
+++ b/tsc/cmake/modules/ProvideTinyclipboard.cmake
@@ -1,5 +1,5 @@
 if (USE_SYSTEM_TINYCLIPBOARD)
-  find_file(Tinyclipboard_INCLUDE_DIRS tinyclipboard.h)
+  find_path(Tinyclipboard_INCLUDE_DIRS tinyclipboard.h)
   find_library(Tinyclipboard_LIBRARIES tinyclipboard)
   message("-- Found tinyclipboard at ${Tinyclipboard_LIBRARIES}")
 else()

--- a/tsc/extras/tsc.appdata.xml
+++ b/tsc/extras/tsc.appdata.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>org.secretchronicles.TSC</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>The Secret Chronicles of Dr. M.</name>
+  <summary>Pursue Dr. M. in this two-dimensional platform game</summary>
+  <description>
+    <p>
+      The Secret Chronicles of Dr. M. (TSC) is a two-dimensional sidecrolling platform game based
+      on OpenGL and SDL. The game features a rich set of levels plus an advanced level editor that
+      allows you to create your own levels. It is accompanied by a powerful scripting engine that
+      utilises mruby, a minimal implementation of the Ruby programming language.
+    </p>
+  </description>
+  <categories>
+    <category>Game</category>
+    <category>ArcadeGame</category>
+  </categories>
+  <url type="homepage">https://secretchronicles.org/</url>
+  <url type="bugtracker">https://github.com/Secretchronicles/TSC/issues</url>
+  <url type="help">https://secretchronicles.org/en/community/</url>
+  <launchable type="desktop-id">tsc.desktop</launchable>
+
+  <releases>
+    <release date="2015-08-17" version="2.0.0" />
+  </releases>
+
+  <developer_name>The Secret Chronicles of Dr. M.</developer_name>
+  <project_license>GPL-3.0+</project_license>
+
+  <screenshots>
+    <screenshot type="default">https://secretchronicles.org/assets/screenshots/6.png</screenshot>
+    <screenshot>https://secretchronicles.org/assets/screenshots/11.png</screenshot>
+    <screenshot>https://secretchronicles.org/assets/screenshots/13.png</screenshot>
+  </screenshots>
+
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">moderate</content_attribute>
+    <content_attribute id="violence-fantasy">moderate</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">mild</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-info">intense</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>


### PR DESCRIPTION
### What exactly is this?

This PR adds a support for building a TSC [Flatpak](https://flatpak.org/). This has a bunch of different benefits, from distribution to contributing.

### Distribution

Flatpak is basically yet another distribution platform for Linux that has been brought up here before. There are a couple of highlights here:

- Supports different repositories, but has an official one, Flathub, meaning we could throw TSC 2.1 up there to make downloading super easy.

### Building

TSC has some hard-to-build dependencies (actually, mostly just CEGUI) that can make contributing difficult. Flatpak-builder largely solves this by having builds in an isolated environment, too.

### IDE support

One other nicety (which is actually what inspired me to do this) is that you get great IDE support. I can open up the CMakeLists.txt in GNOME Builder and immediately have a full development environment with all the dependencies set up. Same apparently goes for KDevelop (FWIW KDE now primarily uses Flatpak for nighties).

### TL;DR

It makes everything easier!