### PR TITLE
mruby use RANGE_* macros

### DIFF
--- a/tsc/src/scripting/objects/sprites/mrb_particle_emitter.cpp
+++ b/tsc/src/scripting/objects/sprites/mrb_particle_emitter.cpp
@@ -63,8 +63,8 @@ static void calculate_rand_values(mrb_state* p_state, mrb_value obj, mrb_float& 
     switch (mrb_type(obj)) {
     case MRB_TT_RANGE:
         p_range = mrb_range_ptr(p_state, obj);
-        beg = mrbnum2float(p_state, p_range->edges->beg);
-        end = mrbnum2float(p_state, p_range->edges->end);
+        beg = mrbnum2float(p_state, RANGE_BEG(p_range));
+        end = mrbnum2float(p_state, RANGE_END(p_range));
 
         value = (end + beg) / 2.0; // mean
         rand = end - value;


### PR DESCRIPTION
Use `RANGE_*` macros to be independent of the `RRange` struct implementation.

Mostly relevant if using system's mruby.