### PR TITLE
Add missing include

### DIFF
--- a/tsc/scrdg/scrdg.cpp
+++ b/tsc/scrdg/scrdg.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "scrdg.hpp"
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <cstdio>


### PR DESCRIPTION
std::sort requires <algorithm>.