### PR TITLE
Add missing header for filestream classes

### DIFF
--- a/tsc/scrdg/scrdg.cpp
+++ b/tsc/scrdg/scrdg.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <iostream>
 #include <sstream>
+#include <fstream>
 #include <cstdio>
 #include <pod.hpp>
 


### PR DESCRIPTION
One more header is missing for current gcc