### PR TITLE
Second Spanish translation finished

### DIFF
--- a/build-tsc.sh
+++ b/build-tsc.sh
@@ -16,7 +16,7 @@ cd build
 rm -rf ../tsc
 
 # Build TSC
-cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../tsc ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../tsc ..
 make -j$(nproc)
 
 # Install TSC to $HOME/tsc

--- a/build-tsc.sh
+++ b/build-tsc.sh
@@ -16,7 +16,7 @@ cd build
 rm -rf ../tsc
 
 # Build TSC
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../tsc ..
+cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../tsc ..
 make -j$(nproc)
 
 # Install TSC to $HOME/tsc

--- a/tsc/data/translations/es.po
+++ b/tsc/data/translations/es.po
@@ -194,11 +194,11 @@ msgstr "Huesos"
 
 #: ../../src/level/level_editor.cpp:394
 msgid "Windows"
-msgstr "MICROSOFT"
+msgstr "Ventanas"
 
 #: ../../src/level/level_editor.cpp:395
 msgid "Candy"
-msgstr "Caramelos"
+msgstr "Dulces"
 
 #: ../../src/level/level_editor.cpp:396
 msgid "Stuff"
@@ -394,7 +394,7 @@ msgstr "Ventana de Depuración"
 #: ../../src/gui/debug_window.cpp:103
 #, c-format
 msgid "[colour='FFFFFF00']FPS: Best: %.02f Worst: %.02f Current: %0.2f"
-msgstr ""
+msgstr "colour='FFFFFF00']FPS: Mejor: %.02f Peor: %.02f Actual: %0.2f"
 
 #: ../../src/gui/debug_window.cpp:111
 msgid "Camera X: %d Y: %d"
@@ -403,11 +403,11 @@ msgstr "Cámara X: %d Y: %d"
 #: ../../src/gui/debug_window.cpp:121
 #, c-format
 msgid "Level: %s (return stack size: %ld)"
-msgstr ""
+msgstr "Level: %s (tamaño del stack: %ld)"
 
 #: ../../src/gui/debug_window.cpp:126
 msgid "Overworld: %s"
-msgstr "Cargar mundo"
+msgstr "Mundo: %s"
 
 #: ../../src/gui/debug_window.cpp:130
 #, fuzzy, c-format
@@ -417,7 +417,7 @@ msgstr "Menú del Nivel"
 #: ../../src/gui/debug_window.cpp:133
 #, c-format
 msgid "Scene: %s"
-msgstr ""
+msgstr "Escena: %s"
 
 #. TRANS: Abbreviations mean:
 #. TRANS: T=Total, P=Passive, M=Massive, E=Enemy, A=Active, H=Halfmassive
@@ -486,12 +486,12 @@ msgstr ""
 #: ../../src/gui/game_console.cpp:181
 #, c-format
 msgid "You are running TSC version %d.%d.%d-%s.\n"
-msgstr ""
+msgstr "Versión de TSC: %d.%d.%d-%s.\n"
 
 #: ../../src/gui/game_console.cpp:187
 #, c-format
 msgid "You are running TSC version %d.%d.%d.\n"
-msgstr ""
+msgstr "Versión de TSC: %d.%d.%d.\n"
 
 #: ../../src/gui/game_console.cpp:239
 msgid "(#inspect did not return a string)\n"
@@ -547,12 +547,12 @@ msgid ""
 "Mixed: See the colors"
 
 msgstr ""
-"- Color en los niveles-\n"
+"- Color en los niveles -\n"
 "\n"
 "Naranja: Del juego\n"
 "Verde: Del usuario\n"
 "Gris: Corrupto\n"
-"Mixto: Modificado"
+"Naranja y verde: Modificado"
 
 #: ../../src/gui/menu_data.cpp:809 ../../src/gui/menu_data.cpp:851
 #: ../../src/gui/menu_data.cpp:877
@@ -618,11 +618,11 @@ msgstr "No"
 
 #: ../../src/gui/menu_data.cpp:1482
 msgid "Camera Hor Speed"
-msgstr "Cámara vel. X"
+msgstr "Velocidad de cámara X"
 
 #: ../../src/gui/menu_data.cpp:1491
 msgid "Camera Ver Speed"
-msgstr "Cámara vel. Y"
+msgstr "Velocidad de cámara Y"
 
 #: ../../src/gui/menu_data.cpp:1500
 msgid "Language"
@@ -641,7 +641,7 @@ msgstr "Nivel del menú principal"
 #: ../../src/gui/menu_data.cpp:1801 ../../src/gui/menu_data.cpp:1831
 #: ../../src/gui/menu_data.cpp:1932 ../../src/gui/menu_data.cpp:1995
 msgid "Reset"
-msgstr "Resetear"
+msgstr "Reestablecer"
 
 #: ../../src/gui/menu_data.cpp:1558
 msgid "Resolution"
@@ -661,11 +661,11 @@ msgstr "VSync"
 
 #: ../../src/gui/menu_data.cpp:1671
 msgid "FPS Limit"
-msgstr "Límite de fps."
+msgstr "FPS"
 
 #: ../../src/gui/menu_data.cpp:1680
 msgid "Geometry Quality"
-msgstr "Calidad poligonal"
+msgstr "Calidad del trazado"
 
 #: ../../src/gui/menu_data.cpp:1688
 msgid "Texture Quality"
@@ -685,7 +685,7 @@ msgstr "Hercios (Hz)"
 
 #: ../../src/gui/menu_data.cpp:1717
 msgid "You should only change the value if the audio is scratchy."
-msgstr "Cambia este valor solo si el sonido se distorsiona. "
+msgstr "Cambia este valor si el sonido se distorsiona. "
 
 #: ../../src/gui/menu_data.cpp:1739
 msgid "Music"
@@ -694,8 +694,8 @@ msgstr "Música"
 #: ../../src/gui/menu_data.cpp:1740
 msgid "Enable to play music. You need to have the Music Addon installed."
 msgstr ""
-"Esto activa la música del juego, pero necesitas tener el Addon de "
-"Música instalado."
+"Esto activa la música del juego, pero primero necesitas tener la música "
+"instalada."
 
 #: ../../src/gui/menu_data.cpp:1762
 msgid "Set the Music Volume."
@@ -711,7 +711,7 @@ msgstr "Activa el sonido."
 
 #: ../../src/gui/menu_data.cpp:1793
 msgid "Set the Sound Volume."
-msgstr "Ajusta el volumen de los sonidos"
+msgstr "Ajusta el volumen de los sonidos."
 
 #: ../../src/gui/menu_data.cpp:1810 ../../src/gui/menu_data.cpp:1919
 msgid "Shortcuts"
@@ -727,7 +727,7 @@ msgstr "Tecla"
 
 #: ../../src/gui/menu_data.cpp:1822
 msgid "Scroll Speed"
-msgstr "No toques esto. Es inútil."
+msgstr "Velocidad de desplazamiento"
 
 #: ../../src/gui/menu_data.cpp:1840
 msgid "Sensitivity"
@@ -883,8 +883,8 @@ msgid ""
 "3000 Points needed for saving in a level.\n"
 "Saving on the Overworld is free."
 msgstr ""
-"Necesitas 3000 puntos para guardar. \n"
-"Guardar en un mundo no requiere puntos."
+"Necesitas 3000 puntos para guardar,\n"
+"aunque no necesitas puntos para guardar en un mundo."
 
 #: ../../src/gui/menu_data.cpp:3287 ../../src/gui/menu_data.cpp:3291
 #: ../../src/gui/menu_data.cpp:3296
@@ -893,24 +893,24 @@ msgstr "Sin descripción"
 
 #: ../../src/gui/menu_data.cpp:3300
 msgid "Enter Description"
-msgstr "Introduce una descripción"
+msgstr "Añade una descripción"
 
 #: ../../src/gui/menu_data.cpp:3318 ../../src/gui/menu_data.cpp:3323
 #: ../../src/gui/menu_data.cpp:3328
 msgid "Savegame loading failed"
-msgstr "Carga fallida"
+msgstr "No se pudo cargar la partida."
 
 #: ../../src/user/savegame/savegame.cpp:271
 msgid "Savegame "
-msgstr "Partida guardada"
+msgstr "Partida "
 
 #: ../../src/user/savegame/savegame.cpp:271
 msgid " loaded"
-msgstr " cargado"
+msgstr " cargada"
 
 #: ../../src/user/savegame/savegame.cpp:436
 msgid "Couldn't save savegame "
-msgstr "No se pudo guardar el nivel"
+msgstr "No se pudo guardar la partida"
 
 #: ../../src/user/savegame/savegame.cpp:439
 msgid "Saved to Slot "
@@ -944,11 +944,11 @@ msgstr "Carga de Nivel fallida :"
 
 #: ../../src/core/game_core.cpp:361
 msgid "Loading Images"
-msgstr "Cargando Imágenes"
+msgstr "Cargando imágenes."
 
 #: ../../src/core/game_core.cpp:498
 msgid "Loading Sounds"
-msgstr "Cargando Sonidos"
+msgstr "Cargando sonido."
 
 #: ../../src/core/property_helper.cpp:514
 #: ../../src/core/property_helper.cpp:764
@@ -1269,8 +1269,8 @@ msgstr ""
 #, c-format
 msgid "Change selected sprite's image"
 msgid_plural "Change selected %d sprites' images"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Cambiar la imagen del sprite"
+msgstr[1] "Cambiar la imagen de %d sprites"
 
 #. TRANS: Displayed when hovering over the level finish object in the editor.
 #: ../../src/core/editor/editor.cpp:1575
@@ -1328,15 +1328,15 @@ msgstr "Mundo "
 
 #: ../../src/overworld/overworld.cpp:466
 msgid "Omega Mode unlocks all waypoints"
-msgstr "El modo omega desbloquea todos los puntos de acceso"
+msgstr "El modo Omega desbloquea todos los puntos de acceso"
 
 #: ../../src/overworld/world_layer.cpp:50
 msgid "Line Start Point"
-msgstr "Inicial de la línea"
+msgstr "Extremo de partida"
 
 #: ../../src/overworld/world_layer.cpp:54
 msgid "Line End Point"
-msgstr "Final de la línea"
+msgstr "Extremo de llegada"
 
 #: ../../src/overworld/world_layer.cpp:289
 msgid "Waypoint origin"
@@ -1453,7 +1453,7 @@ msgstr "Acceso por defecto"
 
 #: ../../src/overworld/world_waypoint.cpp:551
 msgid "Enable if the Waypoint should be always accessible."
-msgstr "Activar si el punto de paso debe estar siempre accesible"
+msgstr "Hace que el punto de acceso siempre esté activado."
 
 #: ../../src/overworld/world_waypoint.cpp:558
 msgid "Waypoint Exit"


### PR DESCRIPTION
The second version of the Spanish translation is here. It doesn't contain a lot of changes, but I finally removed the silly jokes of the first version, and now the translation sounds more natural instead of looking as a Google translate translation. I realized that Omega mode was "not working" (it was) due to the game being a debug release. If you want to test features only available in "release-type" updates (such as Omega mode) or just make them work again, you only need to change `-DCMAKE_BUILD_TYPE=Debug` to `-DCMAKE_BUILD_TYPE=Release`. Please note that this translation contains a handful of things with another arrangement/use of words due to language differences. When speaking/writing in Spanish, even an "accurate" translation can be deprecated because no one talks that way. The translation tries to keep the original message while still sounding natural.